### PR TITLE
fix: report git source control badge count

### DIFF
--- a/packages/extension/src/parts/GetBadgeCount/GetBadgeCount.ts
+++ b/packages/extension/src/parts/GetBadgeCount/GetBadgeCount.ts
@@ -1,3 +1,17 @@
-export const getBadgeCount = async (cwd) => {
-  return 0
+import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as GitWorkerCommandType from '../GitWorkerCommandType/GitWorkerCommandType.ts'
+
+export const getBadgeCount = async (cwd): Promise<number> => {
+  const groups = await GitWorker.invoke(GitWorkerCommandType.GitGetGroups, {})
+  if (!Array.isArray(groups)) {
+    return 0
+  }
+  let badgeCount = 0
+  for (const group of groups) {
+    if (!group || !Array.isArray(group.items)) {
+      continue
+    }
+    badgeCount += group.items.length
+  }
+  return badgeCount
 }


### PR DESCRIPTION
Makes the Git source control provider return a badge count based on the current Git source control groups instead of always returning zero.