### PR TITLE
fix: mark git as incompatible with web

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -3,6 +3,9 @@
   "name": "Git",
   "description": "Git SCM Integration",
   "browser": "dist/gitMain.js",
+  "compatibility": {
+    "web": false
+  },
   "icon": "./icon.png",
   "activation": [
     "onCommand:git.init",


### PR DESCRIPTION
Summary:
- declare the built-in Git extension incompatible with web runtimes
- keep Git available for Electron and remote runtimes