### PR TITLE
fix: enable git branch picker

### DIFF
--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -21,12 +21,6 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await FileSystem.mkdir(workspaceDir)
   await Workspace.setPath(workspaceDir)
   await Git.init({ initialBranch: 'main' })
-  await SideBar.open('Source Control')
-
-  const branchStatusBarItem = Locator('.StatusBarItem[data-name="git.showBranchPicker"], .StatusBarItem[name="git.showBranchPicker"]')
-  await expect(branchStatusBarItem).toBeVisible()
-  await expect(branchStatusBarItem).toHaveText('main')
-
   await Git.config({
     'user.email': 'test@example.com',
     'user.name': 'Test User',
@@ -34,6 +28,12 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'main branch')
   await Git.addAll()
   await Git.commit('Initial commit')
+  await SideBar.open('Source Control')
+
+  const branchStatusBarItem = Locator('.StatusBarItem[data-name="git.showBranchPicker"], .StatusBarItem[name="git.showBranchPicker"]')
+  await expect(branchStatusBarItem).toBeVisible()
+  await expect(branchStatusBarItem).toHaveText('main')
+
   await Git.branch('feature')
   await Git.checkout('feature')
   await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'feature branch')

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -14,25 +14,39 @@ const waitForFileContent = async (FileSystem: { readFile: (uri: string) => Promi
   throw new Error(`expected ${uri} to be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
 }
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPick, SideBar, Workspace }) => {
+export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, QuickPick, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
-  await Workspace.setPath(tmpDir)
-  const fixtureUrl = import.meta.resolve('../fixtures/git-api-checkout')
-  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await FileSystem.mkdir(workspaceDir)
   await Workspace.setPath(workspaceDir)
-  await SideBar.open('Source Control')
+  await Git.init({ initialBranch: 'main' })
 
   const branchStatusBarItem = Locator('.StatusBarItem[name="git.showBranchPicker"]')
   await expect(branchStatusBarItem).toBeVisible()
   await expect(branchStatusBarItem).toHaveText('main')
 
+  await Git.config({
+    'user.email': 'test@example.com',
+    'user.name': 'Test User',
+  })
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'main branch')
+  await Git.addAll()
+  await Git.commit('Initial commit')
+  await Git.branch('feature')
+  await Git.checkout('feature')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'feature branch')
+  await Git.addAll()
+  await Git.commit('Feature commit')
+  await Git.checkout('main')
+  await SideBar.open('Source Control')
+  await expect(branchStatusBarItem).toHaveText('main')
+
   // act
   const branchPickerPromise = Command.execute('StatusBar.handleClick', 'git.showBranchPicker')
   const quickPick = Locator('#QuickPick')
-  const featureBranchItem = Locator('text=feature')
-  const mainBranchItem = Locator('text=main')
+  const featureBranchItem = quickPick.locator('text=feature')
+  const mainBranchItem = quickPick.locator('text=main')
   await expect(quickPick).toBeVisible()
   await expect(featureBranchItem).toBeVisible()
   await expect(mainBranchItem).toBeVisible()

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -21,6 +21,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await FileSystem.mkdir(workspaceDir)
   await Workspace.setPath(workspaceDir)
   await Git.init({ initialBranch: 'main' })
+  await SideBar.open('Source Control')
 
   const branchStatusBarItem = Locator('.StatusBarItem[name="git.showBranchPicker"]')
   await expect(branchStatusBarItem).toBeVisible()
@@ -39,7 +40,6 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await Git.addAll()
   await Git.commit('Feature commit')
   await Git.checkout('main')
-  await SideBar.open('Source Control')
   await expect(branchStatusBarItem).toHaveText('main')
 
   // act

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -23,7 +23,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await Git.init({ initialBranch: 'main' })
   await SideBar.open('Source Control')
 
-  const branchStatusBarItem = Locator('.StatusBarItem[name="git.showBranchPicker"]')
+  const branchStatusBarItem = Locator('.StatusBarItem[data-name="git.showBranchPicker"], .StatusBarItem[name="git.showBranchPicker"]')
   await expect(branchStatusBarItem).toBeVisible()
   await expect(branchStatusBarItem).toHaveText('main')
 

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -24,7 +24,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPi
   await Workspace.setPath(workspaceDir)
   await SideBar.open('Source Control')
 
-  const branchStatusBarItem = Locator('.StatusBarItem[data-name="git.showBranchPicker"]')
+  const branchStatusBarItem = Locator('.StatusBarItem[name="git.showBranchPicker"]')
   await expect(branchStatusBarItem).toBeVisible()
   await expect(branchStatusBarItem).toHaveText('main')
 

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -2,22 +2,44 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.status-bar-select-branch'
 
-export const skip = 1
+const waitForFileContent = async (FileSystem: { readFile: (uri: string) => Promise<string> }, uri: string, expected: string): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    const actual = await FileSystem.readFile(uri)
+    if (actual === expected) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  const actual = await FileSystem.readFile(uri)
+  throw new Error(`expected ${uri} to be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar, Workspace }) => {
+export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPick, SideBar, Workspace }) => {
   // arrange
-  // const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
-  // const workspaceDir = `${tmpDir}/workspace`
-  // await Workspace.setPath(tmpDir)
-  // const fixtureUrl = import.meta.resolve('../fixtures/git-api-checkout')
-  // TODO
-  // await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
-  // await Workspace.setPath(workspaceDir)
-  // await SideBar.open('Source Control')
-  // // act
-  // await Locator('.StatusBarItem[data-name="git.selectBranch"]').click()
-  // // assert
-  // await expect(Locator('#QuickPick')).toBeVisible()
-  // await expect(Locator('text=feature')).toBeVisible()
-  // await expect(Locator('text=main')).toBeVisible()
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-checkout')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await SideBar.open('Source Control')
+
+  const branchStatusBarItem = Locator('.StatusBarItem[data-name="git.showBranchPicker"]')
+  await expect(branchStatusBarItem).toBeVisible()
+  await expect(branchStatusBarItem).toHaveText('main')
+
+  // act
+  const branchPickerPromise = Command.execute('StatusBar.handleClick', 'git.showBranchPicker')
+  const quickPick = Locator('#QuickPick')
+  const featureBranchItem = Locator('text=feature')
+  const mainBranchItem = Locator('text=main')
+  await expect(quickPick).toBeVisible()
+  await expect(featureBranchItem).toBeVisible()
+  await expect(mainBranchItem).toBeVisible()
+  await QuickPick.selectItem('feature')
+  await branchPickerPromise
+
+  // assert
+  await waitForFileContent(FileSystem, `${workspaceDir}/.git/HEAD`, 'ref: refs/heads/feature\n')
+  await expect(branchStatusBarItem).toHaveText('feature')
 }

--- a/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitCheckout.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitCheckout.ts
@@ -1,8 +1,11 @@
 import * as CommandId from '../CommandId/CommandId.ts'
 import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 
 export const id = CommandId.GitCheckout
 
 export const execute = async (ref) => {
-  return GitWorker.invoke('Git.checkout', { ref })
+  const result = await GitWorker.invoke('Git.checkout', { ref })
+  await StatusBarCheckout.refresh()
+  return result
 }

--- a/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitInit.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitInit.ts
@@ -1,5 +1,6 @@
 import * as CommandId from '../CommandId/CommandId.ts'
 import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 
 export const id = CommandId.GitInit
 
@@ -18,5 +19,7 @@ export const execute = async (options: GitInitOptions = {}) => {
           initialBranch: options.initialBranch,
         }
       : {}
-  return GitWorker.invoke('Command.gitInit', initOptions)
+  const result = await GitWorker.invoke('Command.gitInit', initOptions)
+  await StatusBarCheckout.refresh(options.uri)
+  return result
 }

--- a/packages/extension/src/parts/ExtensionHostCommand/ShowBranchPicker.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ShowBranchPicker.ts
@@ -1,5 +1,10 @@
 import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 
 export const showBranchPicker = async () => {
-  return GitWorker.invoke('Command.gitCheckoutRef')
+  const selectedBranch = await GitWorker.invoke('Command.gitCheckoutRef')
+  if (selectedBranch) {
+    await StatusBarCheckout.refresh()
+  }
+  return selectedBranch
 }

--- a/packages/extension/src/parts/Main/Main.ts
+++ b/packages/extension/src/parts/Main/Main.ts
@@ -1,5 +1,6 @@
 import { activate as activateExtensionApi, registerCommand, registerSourceControlProvider } from '@lvce-editor/api'
 import * as ExtensionHostCommand from '../ExtensionHostCommand/ExtensionHostCommand.ts'
+import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 import * as SourceControlProviderGit from '../UiSourceControlProvider/UiSourceControlProviderGit.ts'
 
 const state = {
@@ -18,6 +19,8 @@ export const activate = async (): Promise<void> => {
   }
 
   registerSourceControlProvider(SourceControlProviderGit)
+  StatusBarCheckout.initialize()
+  await StatusBarCheckout.refresh()
 }
 
 export const deactivate = (): void => {}

--- a/packages/extension/src/parts/QuickPick/QuickPick.ts
+++ b/packages/extension/src/parts/QuickPick/QuickPick.ts
@@ -10,5 +10,6 @@ const toPick = (pick) => {
 export const show = async (picks) => {
   return showQuickPick({
     items: picks.map(toPick),
+    placeholder: 'Select a branch',
   })
 }

--- a/packages/extension/src/parts/StatusBarCheckout/StatusBarCheckout.ts
+++ b/packages/extension/src/parts/StatusBarCheckout/StatusBarCheckout.ts
@@ -1,0 +1,42 @@
+import { registerStatusBarItemProvider } from '@lvce-editor/api'
+import * as CommandId from '../CommandId/CommandId.ts'
+import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as GitWorkerCommandType from '../GitWorkerCommandType/GitWorkerCommandType.ts'
+
+const providerId = 'git.checkout'
+
+const state: {
+  branch: string
+  handle: undefined | { refresh(): Promise<void> }
+} = {
+  branch: '',
+  handle: undefined,
+}
+
+const getStatusBarItem = () => {
+  if (!state.branch) {
+    return undefined
+  }
+  return {
+    icon: 'branch',
+    name: CommandId.GitShowBranchPicker,
+    onClick: CommandId.GitShowBranchPicker,
+    text: state.branch,
+  }
+}
+
+export const initialize = (): void => {
+  state.handle = registerStatusBarItemProvider({
+    getStatusBarItem,
+    id: providerId,
+  })
+}
+
+export const refresh = async (cwd?: string): Promise<void> => {
+  try {
+    state.branch = await GitWorker.invoke(GitWorkerCommandType.GitGetCurrentBranch, { cwd })
+  } catch {
+    state.branch = ''
+  }
+  await state.handle?.refresh()
+}

--- a/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
+++ b/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
@@ -7,7 +7,7 @@ import * as GetChangedFiles from '../GetChangedFiles/GetChangedFiles.ts'
 import * as GetFileBefore from '../GetFileBefore/GetFileBefore.ts'
 import * as GetGroups from '../GetGroups/GetGroups.ts'
 import * as GetDecorations from '../GetDecorations/GetDecorations.ts'
-import * as CommandId from '../CommandId/CommandId.ts'
+import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 
 export const id = 'git'
 
@@ -33,7 +33,11 @@ export const isActive = async (scheme, root) => {
       cwd: root,
       reject: false,
     })
-    return exitCode === 0
+    const isGitRepository = exitCode === 0
+    if (isGitRepository) {
+      await StatusBarCheckout.refresh(root)
+    }
+    return isGitRepository
   } catch (error) {
     console.log({ error })
     return false
@@ -51,24 +55,3 @@ export const getGroups = GetGroups.getGroups
 export const getFileBefore = GetFileBefore.getFileBefore
 
 export const fetch = CommandFetch
-
-export const statusBarCommands = [
-  {
-    text: 'select branch',
-  },
-]
-
-export const handleClickBranch = () => {
-  // TODO
-}
-
-export const getStatusBarItems = () => {
-  return [
-    {
-      icon: 'branch',
-      text: 'select branch',
-      name: CommandId.GitShowBranchPicker,
-      onClick: CommandId.GitShowBranchPicker,
-    },
-  ]
-}

--- a/packages/git-worker/src/parts/CommandCheckout/CommandCheckout.ts
+++ b/packages/git-worker/src/parts/CommandCheckout/CommandCheckout.ts
@@ -5,7 +5,7 @@ import * as GitRepositoriesRequests from '../GitRepositoriesRequests/GitReposito
 import * as GitRequests from '../GitRequests/GitRequests.ts'
 import * as Rpc from '../Rpc/Rpc.ts'
 
-export const commandCheckout = async (): Promise<void> => {
+export const commandCheckout = async (): Promise<string | undefined> => {
   const picks = await GetCheckoutPicks.getCheckoutPicks()
   const selectedPick = await Rpc.invoke('QuickPick.show', picks)
   if (!selectedPick) {
@@ -23,5 +23,5 @@ export const commandCheckout = async (): Promise<void> => {
     fn: GitRequests.checkout,
     id: 'checkout',
   })
-  // console.log({ selectedPick })
+  return label
 }

--- a/packages/git-worker/test/CommandCheckout.test.ts
+++ b/packages/git-worker/test/CommandCheckout.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable jest/no-restricted-jest-methods */
+import { jest } from '@jest/globals'
+import type * as GetCheckoutPicks from '../src/parts/GetCheckoutPicks/GetCheckoutPicks.ts'
+import type * as GitRepositories from '../src/parts/GitRepositories/GitRepositories.ts'
+import type * as GitRepositoriesRequests from '../src/parts/GitRepositoriesRequests/GitRepositoriesRequests.ts'
+import type * as Rpc from '../src/parts/Rpc/Rpc.ts'
+
+const mockGetCheckoutPicks = jest.fn<typeof GetCheckoutPicks.getCheckoutPicks>()
+const mockGetCurrent = jest.fn<typeof GitRepositories.getCurrent>()
+const mockExecute = jest.fn<typeof GitRepositoriesRequests.execute>()
+const mockInvoke = jest.fn<typeof Rpc.invoke>()
+
+jest.unstable_mockModule('../src/parts/GetCheckoutPicks/GetCheckoutPicks.ts', () => ({
+  getCheckoutPicks: mockGetCheckoutPicks,
+}))
+
+jest.unstable_mockModule('../src/parts/GitRepositories/GitRepositories.ts', () => ({
+  getCurrent: mockGetCurrent,
+}))
+
+jest.unstable_mockModule('../src/parts/GitRepositoriesRequests/GitRepositoriesRequests.ts', () => ({
+  execute: mockExecute,
+}))
+
+jest.unstable_mockModule('../src/parts/Rpc/Rpc.ts', () => ({
+  invoke: mockInvoke,
+}))
+
+const CommandCheckout = await import('../src/parts/CommandCheckout/CommandCheckout.ts')
+const Git = await import('../src/parts/Git/Git.ts')
+const GitRequests = await import('../src/parts/GitRequests/GitRequests.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('checks out selected branch', async (): Promise<void> => {
+  const picks = [
+    {
+      description: '1234567',
+      icon: 1,
+      label: 'feature',
+    },
+  ]
+  mockGetCheckoutPicks.mockResolvedValue(picks)
+  mockInvoke.mockResolvedValue(picks[0])
+  mockGetCurrent.mockResolvedValue({
+    gitPath: '/test/git',
+    gitVersion: '2.39.2',
+    path: '/test/folder',
+  })
+  mockExecute.mockResolvedValue(undefined)
+
+  await expect(CommandCheckout.commandCheckout()).resolves.toBe('feature')
+  expect(mockInvoke).toHaveBeenCalledWith('QuickPick.show', picks)
+  expect(mockExecute).toHaveBeenCalledWith({
+    args: {
+      cwd: '/test/folder',
+      exec: Git.exec,
+      gitPath: '/test/git',
+      ref: 'feature',
+    },
+    fn: GitRequests.checkout,
+    id: 'checkout',
+  })
+})
+
+test('does not checkout when quick pick is canceled', async (): Promise<void> => {
+  mockGetCheckoutPicks.mockResolvedValue([])
+  mockInvoke.mockResolvedValue(undefined)
+
+  await expect(CommandCheckout.commandCheckout()).resolves.toBeUndefined()
+  expect(mockExecute).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- show the active Git branch in a registered status bar item
- open the branch quick pick from the status bar and checkout the selected branch
- refresh the branch label after picker and API checkouts, with focused unit and e2e regression coverage