### PR TITLE
fix: name git worker

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -1,6 +1,7 @@
 {
   "id": "builtin.git",
   "name": "Git",
+  "workerName": "Git",
   "description": "Git SCM Integration",
   "browser": "dist/gitMain.js",
   "isolated": true,


### PR DESCRIPTION
Set the isolated extension worker name to Git so developer tooling shows a friendly label instead of the extension ID.