### PR TITLE
fix: resolve git worker from extension bundle

### DIFF
--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -125,7 +125,7 @@ await bundleJs(join(root, 'dist', 'git-worker', 'src', 'gitWorkerMain.ts'), join
 
 await bundleJs(join(root, 'dist', 'git-web', 'src', 'gitWebMain.ts'), join(root, 'dist', 'git-web', 'dist', 'gitWebMain.js'), false)
 
-await bundleJs(join(extension, 'src', 'gitMain.ts'), join(root, 'dist', 'dist', 'gitMain.js'), false)
+await bundleJs(join(root, 'dist', 'src', 'gitMain.ts'), join(root, 'dist', 'dist', 'gitMain.js'), false)
 
 await packageExtension({
   highestCompression: true,

--- a/packages/extension/test/GitWorkerUrl.test.js
+++ b/packages/extension/test/GitWorkerUrl.test.js
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { readFileSync } from 'node:fs'
+
+test('resolves the git worker from the development extension bundle', () => {
+  const sourceUrl = new URL('../src/parts/GitWorkerUrl/GitWorkerUrl.ts', import.meta.url)
+  const source = readFileSync(sourceUrl, 'utf8')
+
+  expect(source).toContain("new URL('../../git-worker/dist/gitWorkerMain.js', import.meta.url)")
+})
+
+test('bundles the rewritten extension source for the packaged layout', () => {
+  const sourceUrl = new URL('../../build/src/build.ts', import.meta.url)
+  const source = readFileSync(sourceUrl, 'utf8')
+
+  expect(source).toContain("bundleJs(join(root, 'dist', 'src', 'gitMain.ts')")
+})


### PR DESCRIPTION
## Summary
- resolve the nested Git worker relative to the packaged extension bundle
- add a regression assertion for the packaged worker path

## Validation
- focused Jest regression test
- npm run build (bundle contains corrected URL)
- npm run type-check
- npm run lint