### PR TITLE
fix: hide branch when workspace closes

### DIFF
--- a/packages/e2e/src/git.status-bar-branch-hidden-on-workspace-close.ts
+++ b/packages/e2e/src/git.status-bar-branch-hidden-on-workspace-close.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.status-bar-branch-hidden-on-workspace-close'
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-checkout')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await SideBar.open('Source Control')
+
+  const statusBarItemBranch = Locator('.StatusBarItem[data-name="git.selectBranch"]')
+  await expect(statusBarItemBranch).toBeVisible()
+
+  // act
+  await Workspace.setPath('')
+
+  // assert
+  await expect(statusBarItemBranch).toBeHidden()
+}

--- a/packages/extension/src/parts/StatusBarCheckout/StatusBarCheckout.ts
+++ b/packages/extension/src/parts/StatusBarCheckout/StatusBarCheckout.ts
@@ -32,6 +32,11 @@ export const initialize = (): void => {
   })
 }
 
+export const clear = async (): Promise<void> => {
+  state.branch = ''
+  await state.handle?.refresh()
+}
+
 export const refresh = async (cwd?: string): Promise<void> => {
   try {
     state.branch = await GitWorker.invoke(GitWorkerCommandType.GitGetCurrentBranch, { cwd })

--- a/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
+++ b/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
@@ -23,9 +23,11 @@ const supportedSchemes = ['file', '', 'memfs']
 
 export const isActive = async (scheme, root) => {
   if (!root) {
+    await StatusBarCheckout.clear()
     return false
   }
   if (!supportedSchemes.includes(scheme)) {
+    await StatusBarCheckout.clear()
     return false
   }
   try {
@@ -36,10 +38,13 @@ export const isActive = async (scheme, root) => {
     const isGitRepository = exitCode === 0
     if (isGitRepository) {
       await StatusBarCheckout.refresh(root)
+    } else {
+      await StatusBarCheckout.clear()
     }
     return isGitRepository
   } catch (error) {
     console.log({ error })
+    await StatusBarCheckout.clear()
     return false
   }
 }


### PR DESCRIPTION
## Summary
- clear the cached Git branch status item whenever the source-control provider becomes inactive
- refresh the status-bar provider for empty, unsupported, non-Git, and failed workspace checks
- record the workspace-close regression in the existing status-bar e2e suite

## Validation
- `npm run type-check`
- `npm run lint` (passes with three existing skipped-test warnings)