### PR TITLE
Show default branch first in branch picker

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,4 +1,4 @@
 {
   "version": "0.2",
-  "words": ["worktree", "gitdir", "lszomoru", "objectname", "pathspec", "uall", "unstash"]
+  "words": ["worktree", "gitdir", "lszomoru", "objectname", "pathspec", "symref", "uall", "unstash"]
 }

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -50,6 +50,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await expect(quickPick).toBeVisible()
   await expect(featureBranchItem).toBeVisible()
   await expect(mainBranchItem).toBeVisible()
+  await expect(quickPick.locator('.QuickPickItem').nth(0)).toContainText('main')
   await QuickPick.selectItem('feature')
   await branchPickerPromise
 

--- a/packages/e2e/src/git.status-bar-select-branch.ts
+++ b/packages/e2e/src/git.status-bar-select-branch.ts
@@ -47,10 +47,11 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   const quickPick = Locator('#QuickPick')
   const featureBranchItem = quickPick.locator('text=feature')
   const mainBranchItem = quickPick.locator('text=main')
+  const firstBranchItem = quickPick.locator('.QuickPickItem').nth(0)
   await expect(quickPick).toBeVisible()
   await expect(featureBranchItem).toBeVisible()
   await expect(mainBranchItem).toBeVisible()
-  await expect(quickPick.locator('.QuickPickItem').nth(0)).toContainText('main')
+  await expect(firstBranchItem).toContainText('main')
   await QuickPick.selectItem('feature')
   await branchPickerPromise
 

--- a/packages/git-requests/src/parts/GitRequestsGetRefs/GitRequestsGetRefs.ts
+++ b/packages/git-requests/src/parts/GitRequestsGetRefs/GitRequestsGetRefs.ts
@@ -5,7 +5,7 @@ import * as ParseGitRefs from '../ParseGitRefs/ParseGitRefs.ts'
 export const getRefs = async ({ cwd, exec, gitPath }: GitRequestContext): Promise<readonly GitRef[]> => {
   try {
     const gitResult = await exec({
-      args: ['for-each-ref', '--format', '%(refname) %(objectname) %(*objectname)'],
+      args: ['for-each-ref', '--format', '%(refname) %(objectname) %(*objectname) %(symref:short)'],
       cwd,
       gitPath,
       name: 'getRefs',

--- a/packages/git-requests/src/parts/ParseGitRef/ParseGitRef.ts
+++ b/packages/git-requests/src/parts/ParseGitRef/ParseGitRef.ts
@@ -1,9 +1,9 @@
 import type { GitRef } from '../Types/Types.ts'
 import * as GitRefType from '../GitRefType/GitRefType.ts'
 
-const RE_REF_1 = /^refs\/heads\/([^ ]+) ([0-9a-f]{40}) ([0-9a-f]{40})?$/
-const RE_REF_2 = /^refs\/remotes\/([^/]+)\/([^ ]+) ([0-9a-f]{40}) ([0-9a-f]{40})?$/
-const RE_REF_3 = /^refs\/tags\/([^ ]+) ([0-9a-f]{40}) ([0-9a-f]{40})?$/
+const RE_REF_1 = /^refs\/heads\/([^ ]+) ([0-9a-f]{40}) (?:([0-9a-f]{40}))?(?: (.*))?$/
+const RE_REF_2 = /^refs\/remotes\/([^/]+)\/([^ ]+) ([0-9a-f]{40}) (?:([0-9a-f]{40}))?(?: (.*))?$/
+const RE_REF_3 = /^refs\/tags\/([^ ]+) ([0-9a-f]{40}) (?:([0-9a-f]{40}))?(?: (.*))?$/
 
 export const parseGitRef = (line: string): GitRef | null => {
   const headMatch = line.match(RE_REF_1)
@@ -21,6 +21,7 @@ export const parseGitRef = (line: string): GitRef | null => {
       commit: remoteMatch[3],
       name: `${remoteMatch[1]}/${remoteMatch[2]}`,
       remote: remoteMatch[1],
+      ...(remoteMatch[5] && { symbolicRef: remoteMatch[5] }),
       type: GitRefType.RemoteHead,
     }
   }

--- a/packages/git-requests/src/parts/Types/Types.ts
+++ b/packages/git-requests/src/parts/Types/Types.ts
@@ -95,6 +95,7 @@ export type GitRef = {
   readonly commit: string
   readonly type: number
   readonly remote: string
+  readonly symbolicRef?: string
 }
 
 export type GitStatusFile = {

--- a/packages/git-requests/test/GitRequestsGetRefs.test.ts
+++ b/packages/git-requests/test/GitRequestsGetRefs.test.ts
@@ -5,10 +5,10 @@ test('getRefs', async (): Promise<void> => {
   const exec = async (): Promise<{ stderr: string; stdout: string }> => {
     return {
       stderr: '',
-      stdout: `refs/remotes/origin/HEAD 903f9903f4f14e0d7ec1a389b9da617848e7f609\u{20}
-refs/remotes/origin/main 903f9903f4f14e0d7ec1a389b9da617848e7f609\u{20}
-refs/remotes/origin/sandy081/powerful-flea 903f9903f4f14e0d7ec1a389b9da617848e7f609\u{20}
-refs/remotes/origin/lszomoru/product-build-parallel 7ed03031bb8511eada0f8418550e33a70e208106\u{20}`,
+      stdout: `refs/remotes/origin/HEAD 903f9903f4f14e0d7ec1a389b9da617848e7f609  origin/main
+refs/remotes/origin/main 903f9903f4f14e0d7ec1a389b9da617848e7f609\u{20}\u{20}
+refs/remotes/origin/sandy081/powerful-flea 903f9903f4f14e0d7ec1a389b9da617848e7f609\u{20}\u{20}
+refs/remotes/origin/lszomoru/product-build-parallel 7ed03031bb8511eada0f8418550e33a70e208106\u{20}\u{20}`,
     }
   }
   expect(
@@ -22,6 +22,7 @@ refs/remotes/origin/lszomoru/product-build-parallel 7ed03031bb8511eada0f8418550e
       commit: '903f9903f4f14e0d7ec1a389b9da617848e7f609',
       name: 'origin/HEAD',
       remote: 'origin',
+      symbolicRef: 'origin/main',
       type: GitRefType.RemoteHead,
     },
     {

--- a/packages/git-worker/src/parts/GetCheckoutPicks/GetCheckoutPicks.ts
+++ b/packages/git-worker/src/parts/GetCheckoutPicks/GetCheckoutPicks.ts
@@ -4,10 +4,13 @@ import * as Git from '../Git/Git.ts'
 import * as Repositories from '../GitRepositories/GitRepositories.ts'
 import * as GitRepositoriesRequests from '../GitRepositoriesRequests/GitRepositoriesRequests.ts'
 import * as GitRequests from '../GitRequests/GitRequests.ts'
+import * as PrioritizeDefaultBranch from '../PrioritizeDefaultBranch/PrioritizeDefaultBranch.ts'
 
 type Ref = {
   commit: string
   name: string
+  remote: string
+  symbolicRef?: string
   type: number
 }
 
@@ -41,5 +44,6 @@ const getRawPicks = async (): Promise<readonly Ref[]> => {
 
 export const getCheckoutPicks = async (): Promise<readonly QuickPickItem[]> => {
   const rawPicks = await getRawPicks()
-  return rawPicks.map(toPick)
+  const prioritizedPicks = PrioritizeDefaultBranch.prioritizeDefaultBranch(rawPicks)
+  return prioritizedPicks.map(toPick)
 }

--- a/packages/git-worker/src/parts/PrioritizeDefaultBranch/PrioritizeDefaultBranch.ts
+++ b/packages/git-worker/src/parts/PrioritizeDefaultBranch/PrioritizeDefaultBranch.ts
@@ -1,0 +1,55 @@
+interface Ref {
+  readonly name: string
+  readonly remote: string
+  readonly symbolicRef?: string
+}
+
+const getRemoteDefaultRef = (refs: readonly Ref[]): string => {
+  const remoteHead = refs.find((ref) => ref.name === 'origin/HEAD') ?? refs.find((ref) => ref.name.endsWith('/HEAD'))
+  return remoteHead?.symbolicRef || ''
+}
+
+const getLocalBranchName = (remoteRef: string): string => {
+  const slashIndex = remoteRef.indexOf('/')
+  return slashIndex === -1 ? remoteRef : remoteRef.slice(slashIndex + 1)
+}
+
+const findPreferredIndex = (refs: readonly Ref[]): number => {
+  const remoteDefaultRef = getRemoteDefaultRef(refs)
+  if (remoteDefaultRef) {
+    const localDefaultBranch = getLocalBranchName(remoteDefaultRef)
+    const localDefaultIndex = refs.findIndex((ref) => !ref.remote && ref.name === localDefaultBranch)
+    if (localDefaultIndex !== -1) {
+      return localDefaultIndex
+    }
+    const remoteDefaultIndex = refs.findIndex((ref) => ref.name === remoteDefaultRef)
+    if (remoteDefaultIndex !== -1) {
+      return remoteDefaultIndex
+    }
+  }
+
+  const mainIndex = refs.findIndex((ref) => !ref.remote && ref.name === 'main')
+  if (mainIndex !== -1) {
+    return mainIndex
+  }
+
+  const remoteMainIndex = refs.findIndex((ref) => ref.remote && ref.name === `${ref.remote}/main`)
+  if (remoteMainIndex !== -1) {
+    return remoteMainIndex
+  }
+
+  const masterIndex = refs.findIndex((ref) => !ref.remote && ref.name === 'master')
+  if (masterIndex !== -1) {
+    return masterIndex
+  }
+
+  return refs.findIndex((ref) => ref.remote && ref.name === `${ref.remote}/master`)
+}
+
+export const prioritizeDefaultBranch = <T extends Ref>(refs: readonly T[]): readonly T[] => {
+  const preferredIndex = findPreferredIndex(refs)
+  if (preferredIndex <= 0) {
+    return refs
+  }
+  return [refs[preferredIndex], ...refs.slice(0, preferredIndex), ...refs.slice(preferredIndex + 1)]
+}

--- a/packages/git-worker/test/PrioritizeDefaultBranch.test.ts
+++ b/packages/git-worker/test/PrioritizeDefaultBranch.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@jest/globals'
+import * as PrioritizeDefaultBranch from '../src/parts/PrioritizeDefaultBranch/PrioritizeDefaultBranch.ts'
+
+const local = (name: string) => ({ name, remote: '' })
+const remote = (name: string, symbolicRef?: string) => ({ name, remote: 'origin', symbolicRef })
+
+test('puts the local remote default branch first', () => {
+  const refs = [local('feature/a'), local('trunk'), remote('origin/HEAD', 'origin/trunk'), remote('origin/trunk')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toEqual([
+    local('trunk'),
+    local('feature/a'),
+    remote('origin/HEAD', 'origin/trunk'),
+    remote('origin/trunk'),
+  ])
+})
+
+test('puts the remote default branch first when there is no local branch', () => {
+  const refs = [local('feature/a'), remote('origin/HEAD', 'origin/trunk'), remote('origin/trunk')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toEqual([
+    remote('origin/trunk'),
+    local('feature/a'),
+    remote('origin/HEAD', 'origin/trunk'),
+  ])
+})
+
+test('falls back to main when the remote default branch is unavailable', () => {
+  const refs = [local('feature/a'), local('main'), local('feature/b')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toEqual([local('main'), local('feature/a'), local('feature/b')])
+})
+
+test('falls back to remote main when there is no local main branch', () => {
+  const refs = [local('feature/a'), remote('origin/main'), local('feature/b')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toEqual([remote('origin/main'), local('feature/a'), local('feature/b')])
+})
+
+test('falls back to master when main is unavailable', () => {
+  const refs = [local('feature/a'), local('master'), local('feature/b')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toEqual([local('master'), local('feature/a'), local('feature/b')])
+})
+
+test('preserves order when no default branch can be identified', () => {
+  const refs = [local('feature/a'), local('feature/b')]
+
+  expect(PrioritizeDefaultBranch.prioritizeDefaultBranch(refs)).toBe(refs)
+})

--- a/packages/git-worker/test/PrioritizeDefaultBranch.test.ts
+++ b/packages/git-worker/test/PrioritizeDefaultBranch.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from '@jest/globals'
 import * as PrioritizeDefaultBranch from '../src/parts/PrioritizeDefaultBranch/PrioritizeDefaultBranch.ts'
 
-const local = (name: string) => ({ name, remote: '' })
-const remote = (name: string, symbolicRef?: string) => ({ name, remote: 'origin', symbolicRef })
+interface Ref {
+  readonly name: string
+  readonly remote: string
+  readonly symbolicRef?: string
+}
+
+const local = (name: string): Ref => ({ name, remote: '' })
+const remote = (name: string, symbolicRef?: string): Ref => ({ name, remote: 'origin', symbolicRef })
 
 test('puts the local remote default branch first', () => {
   const refs = [local('feature/a'), local('trunk'), remote('origin/HEAD', 'origin/trunk'), remote('origin/trunk')]


### PR DESCRIPTION
Prioritizes the repository default branch in the Git checkout picker, with main/master fallbacks.

Adds unit coverage for default-branch detection and an e2e assertion for rendered picker order.