### PR TITLE
Add 20 Git extension end-to-end tests

### DIFF
--- a/packages/e2e/src/git-api-add-all.ts
+++ b/packages/e2e/src/git-api-add-all.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-all'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileNames = ['first.txt', 'second.txt']
+
+  await Workspace.setPath(tmpDir)
+  await FileSystem.setFiles(
+    fileNames.map((fileName) => ({
+      content: `${fileName} content`,
+      uri: `${tmpDir}/${fileName}`,
+    })),
+  )
+  await Git.init()
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.addAll')
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  for (const fileName of fileNames) {
+    if (!indexContent.includes(fileName)) {
+      throw new Error(`expected ${fileName} in git index`)
+    }
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'add', '.'],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-add-file-with-spaces.ts
+++ b/packages/e2e/src/git-api-add-file-with-spaces.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-file-with-spaces'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileName = 'file with spaces.txt'
+
+  await Workspace.setPath(tmpDir)
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'spaced path')
+  await Git.init()
+
+  // act
+  await Git.add(fileName)
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!indexContent.includes(fileName)) {
+    throw new Error(`expected ${fileName} in git index`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'add', fileName],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-add-nested-file.ts
+++ b/packages/e2e/src/git-api-add-nested-file.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-nested-file'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const folderName = 'nested'
+  const fileName = `${folderName}/file.txt`
+
+  await Workspace.setPath(tmpDir)
+  await FileSystem.mkdir(`${tmpDir}/${folderName}`)
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'nested content')
+  await Git.init()
+
+  // act
+  await Git.add(fileName)
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!indexContent.includes(fileName)) {
+    throw new Error(`expected ${fileName} in git index`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'add', fileName],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-add-remote.ts
+++ b/packages/e2e/src/git-api-add-remote.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-remote'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const remoteName = 'backup'
+  const remoteUrl = 'https://example.com/repository.git'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+
+  // act
+  await Git.addRemote(remoteName, remoteUrl)
+
+  // assert
+  const configContent = await FileSystem.readFile(`${workspaceDir}/.git/config`)
+  if (!configContent.includes(`[remote "${remoteName}"]`) || !configContent.includes(`url = ${remoteUrl}`)) {
+    throw new Error(`expected git config to contain ${remoteName} remote, got ${configContent}`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'remote', 'add', remoteName, remoteUrl],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-add-untracked-file.ts
+++ b/packages/e2e/src/git-api-add-untracked-file.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-untracked-file'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileName = 'untracked.txt'
+
+  await Workspace.setPath(tmpDir)
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'new content')
+  await Git.init()
+
+  // act
+  await Git.add(fileName)
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!indexContent.includes(fileName)) {
+    throw new Error(`expected ${fileName} in git index`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'add', fileName],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-branch-with-slash.ts
+++ b/packages/e2e/src/git-api-branch-with-slash.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.branch-with-slash'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const branchName = 'feature/nested'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+
+  // act
+  await Git.branch(branchName)
+
+  // assert
+  const mainRef = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/${branchName}`, mainRef)
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'branch', branchName],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-clean-all-tracked-file.ts
+++ b/packages/e2e/src/git-api-clean-all-tracked-file.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.clean-all-tracked-file'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'modified content')
+
+  // act
+  await Git.cleanAll()
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'restore', '--', '.'],
+      cwd: workspaceDir,
+    },
+    {
+      command: ['git', 'clean', '-fd'],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-clean-all-untracked-directory.ts
+++ b/packages/e2e/src/git-api-clean-all-untracked-directory.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.clean-all-untracked-directory'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const folderName = 'generated'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.mkdir(`${workspaceDir}/${folderName}`)
+  await FileSystem.writeFile(`${workspaceDir}/${folderName}/output.txt`, 'generated content')
+
+  // act
+  await Git.cleanAll()
+
+  // assert
+  const dirents = await FileSystem.readDir(workspaceDir)
+  if (dirents.some((dirent) => dirent.name === folderName)) {
+    throw new Error(`expected ${folderName} to be deleted`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'clean', '-fd'],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-commit-special-characters.ts
+++ b/packages/e2e/src/git-api-commit-special-characters.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.commit-special-characters'
+
+type GitCommit = {
+  readonly hash: string
+  readonly message: string
+}
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const message = "It's ready: [e2e]"
+
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await Git.setConfig('user.name', 'Test User')
+  await Git.setConfig('user.email', 'test@example.com')
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Git.add('file.txt')
+
+  // act
+  await Git.commit(message)
+
+  // assert
+  const commits = (await Command.execute('ExtensionHost.executeCommand', 'git.getCommits')) as readonly GitCommit[]
+  if (commits.length !== 1 || commits[0].message !== message || !commits[0].hash) {
+    throw new Error(`expected commit ${JSON.stringify(message)}, got ${JSON.stringify(commits)}`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'commit', '-m', message],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-discard-cancel.ts
+++ b/packages/e2e/src/git-api-discard-cancel.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.discard-cancel'
+
+export const test: Test = async ({ Command, Dialog, FileSystem, Settings, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const fileName = 'file.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await Settings.update({
+    'git.confirmDiscard': true,
+  })
+  await Dialog.mockConfirm(() => false)
+  await FileSystem.writeFile(`${workspaceDir}/${fileName}`, 'modified content')
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', fileName)
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/${fileName}`, 'modified content')
+}

--- a/packages/e2e/src/git-api-discard-tracked-file.ts
+++ b/packages/e2e/src/git-api-discard-tracked-file.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.discard-tracked-file'
+
+export const test: Test = async ({ Command, Dialog, FileSystem, Git, Settings, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const fileName = 'file.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await Settings.update({
+    'git.confirmDiscard': true,
+  })
+  await Dialog.mockConfirm(() => true)
+  await FileSystem.writeFile(`${workspaceDir}/${fileName}`, 'modified content')
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', fileName)
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/${fileName}`, 'main branch')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'status', '--porcelain', '-uall'],
+      cwd: workspaceDir,
+    },
+    {
+      command: ['git', 'restore', '--', fileName],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-discard-without-confirmation.ts
+++ b/packages/e2e/src/git-api-discard-without-confirmation.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.discard-without-confirmation'
+
+export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const fileName = 'file.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await Settings.update({
+    'git.confirmDiscard': false,
+  })
+  await FileSystem.writeFile(`${workspaceDir}/${fileName}`, 'modified content')
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', fileName)
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/${fileName}`, 'main branch')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'status', '--porcelain', '-uall'],
+      cwd: workspaceDir,
+    },
+    {
+      command: ['git', 'restore', '--', fileName],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-get-commits.ts
+++ b/packages/e2e/src/git-api-get-commits.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.get-commits'
+
+type GitCommit = {
+  readonly hash: string
+  readonly message: string
+}
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+
+  // act
+  const commits = (await Command.execute('ExtensionHost.executeCommand', 'git.getCommits')) as readonly GitCommit[]
+
+  // assert
+  if (commits.length !== 1 || commits[0].message !== 'Initial commit' || !commits[0].hash) {
+    throw new Error(`expected initial commit, got ${JSON.stringify(commits)}`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'log', '--format=%H%x09%s'],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-set-config.ts
+++ b/packages/e2e/src/git-api-set-config.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.set-config'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const key = 'user.name'
+  const value = 'E2E Test User'
+
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.setConfig', key, value)
+
+  // assert
+  const configContent = await FileSystem.readFile(`${tmpDir}/.git/config`)
+  if (!configContent.includes('name = E2E Test User')) {
+    throw new Error(`expected git config to contain user name, got ${configContent}`)
+  }
+}

--- a/packages/e2e/src/git-api-stage-all.ts
+++ b/packages/e2e/src/git-api-stage-all.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stage-all'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileNames = ['alpha.txt', 'beta.txt']
+
+  await Workspace.setPath(tmpDir)
+  await FileSystem.setFiles(
+    fileNames.map((fileName) => ({
+      content: `${fileName} content`,
+      uri: `${tmpDir}/${fileName}`,
+    })),
+  )
+  await Git.init()
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.stageAll')
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  for (const fileName of fileNames) {
+    if (!indexContent.includes(fileName)) {
+      throw new Error(`expected ${fileName} in git index`)
+    }
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'add', '.'],
+      cwd: tmpDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-stash-with-message.ts
+++ b/packages/e2e/src/git-api-stash-with-message.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stash-with-message'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const message = 'work in progress'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-stash')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.stash', {
+    message,
+  })
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'initial content')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'stash', 'push', '--message', message],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-unstage-all-clean-repository.ts
+++ b/packages/e2e/src/git-api-unstage-all-clean-repository.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-all-clean-repository'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.unstageAll')
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'restore', '--staged', '.'],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-unstage-all.ts
+++ b/packages/e2e/src/git-api-unstage-all.ts
@@ -1,0 +1,41 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-all'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const newFileName = 'new.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.setFiles([
+    {
+      content: 'modified content',
+      uri: `${workspaceDir}/file.txt`,
+    },
+    {
+      content: 'new content',
+      uri: `${workspaceDir}/${newFileName}`,
+    },
+  ])
+  await Command.execute('ExtensionHost.executeCommand', 'git.stageAll')
+
+  // act
+  await Command.execute('ExtensionHost.executeCommand', 'git.unstageAll')
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (indexContent.includes(newFileName)) {
+    throw new Error(`expected ${newFileName} to be removed from git index`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'restore', '--staged', '.'],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-unstage-new-file-with-spaces.ts
+++ b/packages/e2e/src/git-api-unstage-new-file-with-spaces.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-new-file-with-spaces'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const fileName = 'new file.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/${fileName}`, 'new content')
+  await Git.add(fileName)
+
+  // act
+  await Git.unstage(fileName)
+
+  // assert
+  const indexContent = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (indexContent.includes(fileName)) {
+    throw new Error(`expected ${fileName} to be removed from git index`)
+  }
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'restore', '--staged', '--', fileName],
+      cwd: workspaceDir,
+    },
+  ])
+}

--- a/packages/e2e/src/git-api-unstage-tracked-file.ts
+++ b/packages/e2e/src/git-api-unstage-tracked-file.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-tracked-file'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const fileName = 'file.txt'
+
+  await Workspace.setPath(tmpDir)
+  const fixtureUrl = import.meta.resolve('../fixtures/git-api-branch')
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', fixtureUrl)
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/${fileName}`, 'modified content')
+  await Git.add(fileName)
+
+  // act
+  await Git.unstage(fileName)
+
+  // assert
+  await FileSystem.shouldHaveFile(`${workspaceDir}/${fileName}`, 'modified content')
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'restore', '--staged', '--', fileName],
+      cwd: workspaceDir,
+    },
+  ])
+}


### PR DESCRIPTION
Adds 20 end-to-end tests for Git extension commands and edge cases, including staging, unstaging, discard flows, configuration, remotes, commits, branches, cleanup, and stashes.