### PR TITLE
fix: bundle git client dependencies

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "type": "module",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "node --test test/buildNodeClient.test.js"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -1,15 +1,14 @@
 import fs, { readFileSync, writeFileSync } from 'node:fs'
-import { readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
 import path, { join } from 'node:path'
 import { bundleJs, packageExtension } from '@lvce-editor/package-extension'
+import { buildNodeClient } from './buildNodeClient.ts'
 import { root } from './root.ts'
 
 const extension = path.join(root, 'packages', 'extension')
 const gitWorker = path.join(root, 'packages', 'git-worker')
 const gitRequests = path.join(root, 'packages', 'git-requests')
 const gitWeb = path.join(root, 'packages', 'git-web')
-const node = path.join(root, 'packages', 'node')
-
 fs.rmSync(join(root, 'dist'), { recursive: true, force: true })
 
 fs.mkdirSync(path.join(root, 'dist'))
@@ -38,11 +37,6 @@ fs.cpSync(join(gitRequests, 'src'), join(root, 'dist', 'git-requests', 'src'), {
 
 fs.cpSync(join(gitWeb, 'src'), join(root, 'dist', 'git-web', 'src'), {
   recursive: true,
-})
-
-fs.cpSync(node, join(root, 'dist', 'node'), {
-  recursive: true,
-  verbatimSymlinks: true,
 })
 
 const replace = async ({ path, occurrence, replacement }: { path: string; occurrence: string; replacement: string }): Promise<void> => {
@@ -106,20 +100,7 @@ await replace({
   replacement: 'parts.slice(0, -3)',
 })
 
-await rm(join(root, 'dist', 'node', 'node_modules', '.bin'), { recursive: true, force: true })
-await rm(join(root, 'dist', 'node', 'node_modules', 'which', 'bin'), { recursive: true, force: true })
-
-const shouldRemoveNodeModule = (dirent: string): boolean => {
-  return dirent.endsWith('test') || dirent.endsWith('.d.ts') || dirent.endsWith('.npmignore') || dirent.endsWith('CHANGELOG.md')
-}
-
-const dirents = await readdir(join(root, 'dist', 'node', 'node_modules'), { recursive: true })
-for (const dirent of dirents) {
-  if (shouldRemoveNodeModule(dirent)) {
-    const absolutePath = join(root, 'dist', 'node', 'node_modules', dirent)
-    await rm(absolutePath, { recursive: true, force: true })
-  }
-}
+await buildNodeClient(join(root, 'dist', 'node', 'src', 'gitClient.js'))
 
 await bundleJs(join(root, 'dist', 'git-worker', 'src', 'gitWorkerMain.ts'), join(root, 'dist', 'git-worker', 'dist', 'gitWorkerMain.js'), false)
 

--- a/packages/build/src/buildNodeClient.ts
+++ b/packages/build/src/buildNodeClient.ts
@@ -1,0 +1,9 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { bundleJs } from '@lvce-editor/package-extension'
+import { root } from './root.ts'
+
+export const buildNodeClient = async (outFile: string): Promise<void> => {
+  await mkdir(dirname(outFile), { recursive: true })
+  await bundleJs(join(root, 'packages', 'node', 'src', 'gitClient.js'), outFile, false)
+}

--- a/packages/build/test/buildNodeClient.test.js
+++ b/packages/build/test/buildNodeClient.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import test from 'node:test'
+import { buildNodeClient } from '../src/buildNodeClient.ts'
+
+test('builds a self-contained node client', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'builtin-git-node-client-'))
+  try {
+    const outFile = join(temporaryDirectory, 'gitClient.js')
+    await buildNodeClient(outFile)
+
+    const gitClient = await import(pathToFileURL(outFile).toString())
+
+    assert.deepEqual(Object.keys(gitClient), ['commandMap'])
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
## Summary

Bundle the node-side Git client into a self-contained file so hoisted transitive dependencies are included in packaged releases. Add regression coverage that loads the built client from an isolated temporary directory.