### PR TITLE
feature: spin status bar icon during sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,9 +2140,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.60.0.tgz",
-      "integrity": "sha512-3v+D1rv3Du9oZ62dfT2vOFameIqq9FQpXCZoal63yWEt5d3OGEbGIcfWm1YmG9LffRDDeXY5/HYPHGXsLXNYog==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.61.0.tgz",
+      "integrity": "sha512-lAYmT0vTwuoWN+m27t+DvrzmtYjUL8gyyy0pUsObOmia8dZHmUV3vhzgWfMaafKRJvAHpal78aqHsAgbBw1XUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15141,7 +15141,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/api": "^8.60.0",
+        "@lvce-editor/api": "^8.61.0",
         "@types/express": "^5.0.6",
         "@types/verror": "^1.10.11",
         "express": "^5.2.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -12,7 +12,7 @@
     "build-min": "microbundle --entry src/gitMain.ts --output distmin --format modern"
   },
   "devDependencies": {
-    "@lvce-editor/api": "^8.60.0",
+    "@lvce-editor/api": "^8.61.0",
     "@types/express": "^5.0.6",
     "@types/verror": "^1.10.11",
     "express": "^5.2.1",

--- a/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitCommitAndSync.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitCommitAndSync.ts
@@ -6,10 +6,15 @@ import * as StatusBarSync from '../StatusBarSync/StatusBarSync.ts'
 export const id = CommandId.GitCommitAndSync
 
 export const execute = async (message) => {
+  await StatusBarSync.setSpinning(true)
   try {
     await GitWorker.invoke(GitWorkerCommandType.GitCommit, { message })
     await GitWorker.invoke('Command.gitSync')
   } finally {
-    await StatusBarSync.refresh()
+    try {
+      await StatusBarSync.refresh()
+    } finally {
+      await StatusBarSync.setSpinning(false)
+    }
   }
 }

--- a/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitSync.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitSync.ts
@@ -5,9 +5,14 @@ import * as StatusBarSync from '../StatusBarSync/StatusBarSync.ts'
 export const id = CommandId.GitSync
 
 export const execute = async () => {
+  await StatusBarSync.setSpinning(true)
   try {
     return await GitWorker.invoke('Command.gitSync')
   } finally {
-    await StatusBarSync.refresh()
+    try {
+      await StatusBarSync.refresh()
+    } finally {
+      await StatusBarSync.setSpinning(false)
+    }
   }
 }

--- a/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitSyncRebase.ts
+++ b/packages/extension/src/parts/ExtensionHostCommand/ExtensionHostCommandGitSyncRebase.ts
@@ -1,8 +1,18 @@
 import * as CommandId from '../CommandId/CommandId.ts'
 import * as GitWorker from '../GitWorker/GitWorker.ts'
+import * as StatusBarSync from '../StatusBarSync/StatusBarSync.ts'
 
 export const id = CommandId.GitSyncRebase
 
-export const execute = () => {
-  return GitWorker.invoke('Command.gitSync')
+export const execute = async () => {
+  await StatusBarSync.setSpinning(true)
+  try {
+    return await GitWorker.invoke('Command.gitSync')
+  } finally {
+    try {
+      await StatusBarSync.refresh()
+    } finally {
+      await StatusBarSync.setSpinning(false)
+    }
+  }
 }

--- a/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
+++ b/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
@@ -14,11 +14,13 @@ const state: {
   handle: undefined | { refresh(): Promise<void> }
   incoming: number
   outgoing: number
+  spinning: boolean
   visible: boolean
 } = {
   handle: undefined,
   incoming: 0,
   outgoing: 0,
+  spinning: false,
   visible: false,
 }
 
@@ -30,6 +32,7 @@ const getStatusBarItem = () => {
     icon: 'MaskIconSync',
     name: CommandId.GitSync,
     onClick: CommandId.GitSync,
+    spinning: state.spinning,
     text: `${state.incoming}↓ ${state.outgoing}↑`,
   }
 }
@@ -45,6 +48,11 @@ export const clear = async (): Promise<void> => {
   state.incoming = 0
   state.outgoing = 0
   state.visible = false
+  await state.handle?.refresh()
+}
+
+export const setSpinning = async (spinning: boolean): Promise<void> => {
+  state.spinning = spinning
   await state.handle?.refresh()
 }
 

--- a/packages/extension/test/ExtensionHostCommandGitCommitAndSync.test.ts
+++ b/packages/extension/test/ExtensionHostCommandGitCommitAndSync.test.ts
@@ -7,6 +7,7 @@ import * as StatusBarSync from '../src/parts/StatusBarSync/StatusBarSync.ts'
 test('execute', async () => {
   const invoke = jest.spyOn(GitWorker, 'invoke').mockImplementation(async () => {})
   const refresh = jest.spyOn(StatusBarSync, 'refresh').mockImplementation(async () => {})
+  const setSpinning = jest.spyOn(StatusBarSync, 'setSpinning').mockImplementation(async () => {})
 
   await ExtensionHostCommandGitCommitAndSync.execute('test message')
 
@@ -14,4 +15,6 @@ test('execute', async () => {
   expect(invoke).toHaveBeenNthCalledWith(1, GitWorkerCommandType.GitCommit, { message: 'test message' })
   expect(invoke).toHaveBeenNthCalledWith(2, 'Command.gitSync')
   expect(refresh).toHaveBeenCalledTimes(1)
+  expect(setSpinning).toHaveBeenNthCalledWith(1, true)
+  expect(setSpinning).toHaveBeenNthCalledWith(2, false)
 })

--- a/packages/extension/test/ExtensionHostCommandGitSync.test.ts
+++ b/packages/extension/test/ExtensionHostCommandGitSync.test.ts
@@ -1,0 +1,36 @@
+import { expect, jest, test } from '@jest/globals'
+import * as ExtensionHostCommandGitSync from '../src/parts/ExtensionHostCommand/ExtensionHostCommandGitSync.ts'
+import * as GitWorker from '../src/parts/GitWorker/GitWorker.ts'
+import * as StatusBarSync from '../src/parts/StatusBarSync/StatusBarSync.ts'
+
+test('execute marks the status bar item as spinning while sync is in progress', async () => {
+  const { promise: syncPromise, resolve: resolveSync } = Promise.withResolvers()
+  const invoke = jest.spyOn(GitWorker, 'invoke').mockImplementation(async () => syncPromise)
+  const refresh = jest.spyOn(StatusBarSync, 'refresh').mockImplementation(async () => {})
+  const setSpinning = jest.spyOn(StatusBarSync, 'setSpinning').mockImplementation(async () => {})
+
+  const result = ExtensionHostCommandGitSync.execute()
+  await Promise.resolve()
+
+  expect(setSpinning).toHaveBeenCalledTimes(1)
+  expect(setSpinning).toHaveBeenCalledWith(true)
+  expect(invoke).toHaveBeenCalledWith('Command.gitSync')
+
+  resolveSync(undefined)
+  await result
+
+  expect(refresh).toHaveBeenCalledTimes(1)
+  expect(setSpinning).toHaveBeenNthCalledWith(2, false)
+})
+
+test('execute stops spinning when sync fails', async () => {
+  jest.spyOn(GitWorker, 'invoke').mockRejectedValue(new Error('sync failed'))
+  const refresh = jest.spyOn(StatusBarSync, 'refresh').mockImplementation(async () => {})
+  const setSpinning = jest.spyOn(StatusBarSync, 'setSpinning').mockImplementation(async () => {})
+
+  await expect(ExtensionHostCommandGitSync.execute()).rejects.toThrow('sync failed')
+
+  expect(refresh).toHaveBeenCalledTimes(1)
+  expect(setSpinning).toHaveBeenNthCalledWith(1, true)
+  expect(setSpinning).toHaveBeenNthCalledWith(2, false)
+})


### PR DESCRIPTION
Marks the Git sync status bar item as spinning while Sync, Sync (Rebase), or Commit & Sync is running, and reliably clears the state after success or failure.