### PR TITLE
fix: describe git sync status accessibly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2158,9 +2158,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-process": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
-      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.12.0.tgz",
+      "integrity": "sha512-lLA01IwXTKdTWXg1ydpsdjHilY3LDT6Ud5DWWaZ6uPwmhTeSIpQ5BP+Fu+8hlZYMW4gUyuFtuYjtDV88S5dF4A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2177,15 +2177,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.23.0.tgz",
+      "integrity": "sha512-hjkqo7QLQl7pL2c+rH54q0/8dSpKDSfF6/3BvBAS2NsSpvtCnab3Ew4bhVyMJrw1c9RnwcC2pmy6iDPtPpz0IQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
-      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.13.1.tgz",
+      "integrity": "sha512-EeadpDQ6hHpJc5OEOSo5Y50ymlYOyltwgYhkZ2c5RtjbYjgwgI4IT7cF9cX4QMaano5/F59IuAsrGKW0OnXabQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2314,14 +2314,14 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.93.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.16.tgz",
-      "integrity": "sha512-W/LF+I+3Lh8CKtre+yoww9br80wNAWgKPWISC6rsG3aAr61WplYCOP8fnYVObNqZiiQHJ9DuMaCEsiRx4FnNkA==",
+      "version": "0.94.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.12.tgz",
+      "integrity": "sha512-cZ+dxNic8snmLePnqzZ4s/VyysZfz5BIEk8+s3fTT3yxf9Bdy40gQ2P90sPpJo/6cPc/XhMS+fWCR+a7nPWYRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/rpc": "^6.12.0",
         "@lvce-editor/verror": "^1.7.0",
         "execa": "^9.6.1",
         "got": "^15.1.0",
@@ -2332,15 +2332,15 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
-      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.7.0.tgz",
+      "integrity": "sha512-tA0GKQ1xwl38YivgPLbCfaYQ/D+EUzL9xn2sOp0yc9imIz6Tf49acI0jLD0/iAodbqeBX6EzjSWRXqXnpa4ygg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "trash": "^10.1.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -2350,9 +2350,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
-      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.9.0.tgz",
+      "integrity": "sha512-bAJwrxnjiLL2Wb/saGDyVg1Rh+fDpBBuFqzTCOkMu4X8J8EZZ+rE1D2/K59lSL868wgsUSMNBE8AWzGLawkUsQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2376,9 +2376,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
-      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.6.0.tgz",
+      "integrity": "sha512-DYP2n651sgxPq6ovBDsuKFo+SnuS6/ipEH64DZGFaBjNJ+PFUrUHq+5gZiUgBM9GifGkyTKFSGL7eq4K5/EETg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -2390,10 +2390,9 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
-      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
-      "dev": true,
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.5.0.tgz",
+      "integrity": "sha512-cBL4jq/DFnbZdyFMk/+nhb3+e4fEPrtyHt0eKPcWb/cauBH5cbju1fwEfmDcT+8oA44ILcF2NoqZ7jnuEeFRgQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -2754,9 +2753,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.0.tgz",
-      "integrity": "sha512-BrGgUrk7BwWS5hm6KczqksVD9bIYVMjaQh2njxt3ZDn2dURXAcNtyfWJlnXelAw7ccUWJXNaS0GlUZxPVG7aXA==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.1.tgz",
+      "integrity": "sha512-C5K/24ThaIoYRq30hBk0jXAtVwQzY2tWNdcbUW72mKNww+EmGhXlHlHA6Cwhz7ae8Q4Dfd9XeekKMBVlNWweTA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2770,9 +2769,9 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
-      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.4.0.tgz",
+      "integrity": "sha512-Ka/MkHduJi6N/42FQuA+Qiz41HzmRnuXiyABZTENQi9/HE/Z+PrXQ92RDpSh9El4lrLX0JNMvhnk2EqgqcJw/Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2798,47 +2797,40 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
-      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.12.0.tgz",
+      "integrity": "sha512-qLaGwjenfbE/3e2LzOsPJazonyZ9GMHbOdYloBtNtzjdd3mre3lFIuCV4D8prq5P1quFiAlGRlgNCDPhb/G7Bg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/ipc": "^16.6.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
-      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
-      "dev": true,
+      "version": "9.43.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.43.0.tgz",
+      "integrity": "sha512-STUNoKvOO9D90p2sk3PXJKwVwEGwArBPB33pCImfBg6HrTP2Q/OPZMzi4HXwseNfusOO6xPlaiXKEND1fgwlOw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.19.0",
+        "@lvce-editor/constants": "^5.23.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
-    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
-      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
-      "license": "MIT"
-    },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
-      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.3.0.tgz",
+      "integrity": "sha512-HakFxJ2h7rWTFFvD/pEcPE1EPvikQpLooxxYkmqt5YhtWl24xikJGrwl/uGVfrsrqp8o1kEZ6DPVY9nvKRjFRw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@lvce-editor/constants": "^5.14.0",
         "execa": "^9.6.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
@@ -2847,18 +2839,18 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^5.1.0"
+        "@lvce-editor/ripgrep": "^5.2.0"
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.93.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.16.tgz",
-      "integrity": "sha512-rsxC6JluPygeDDwSWh8fVzjxWXuo2tMyMGkw1/HMpUwHcT40VIVvmY7G6yUWrCd0XY4LXXZKTbUk9e8wAj3mOQ==",
+      "version": "0.94.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.12.tgz",
+      "integrity": "sha512-H5Q/dTCF1BMxh5VUhabwDGD3+ew8H6sHPGa3QyD/qx72jEIiGSH3MUN0Be06kxI/cHKX7uprPBd03k+weTeNjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.93.16",
-        "@lvce-editor/static-server": "0.93.16"
+        "@lvce-editor/shared-process": "0.94.12",
+        "@lvce-editor/static-server": "0.94.12"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2868,21 +2860,21 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.93.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.16.tgz",
-      "integrity": "sha512-u/E0RntfD/lvNWtJXg/9pq+ptY1Y33Tlo4DA5+tfA9T4nR3VnB58QDjTwUPmNooDmWdaZv9BE8BmstNH/4bCuQ==",
+      "version": "0.94.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.12.tgz",
+      "integrity": "sha512-qJDiVUudpTG/01EKuHedEvdAUTDvfff2x3qLornjmhq4qpVlRv8Kk7oyaBEZh4EzPHfi26+UQQVaABB2cHc7YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.93.16",
-        "@lvce-editor/ipc": "16.4.0",
-        "@lvce-editor/json-rpc": "8.3.0",
+        "@lvce-editor/auth-process": "1.12.0",
+        "@lvce-editor/extension-host-helper-process": "0.94.12",
+        "@lvce-editor/ipc": "16.6.0",
+        "@lvce-editor/json-rpc": "8.5.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.12.0",
-        "@lvce-editor/rpc-registry": "9.36.0",
+        "@lvce-editor/process-explorer": "3.12.1",
+        "@lvce-editor/rpc-registry": "9.43.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
         "markdown-it": "^14.3.0",
@@ -2892,15 +2884,15 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.10.0",
-        "@lvce-editor/file-system-process": "5.5.1",
-        "@lvce-editor/file-watcher-process": "4.6.3",
+        "@lvce-editor/embeds-process": "4.13.1",
+        "@lvce-editor/file-system-process": "5.7.0",
+        "@lvce-editor/file-watcher-process": "4.9.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.3.0",
-        "@lvce-editor/search-process": "15.1.0",
-        "@lvce-editor/typescript-compile-process": "5.4.0",
+        "@lvce-editor/pty-host": "8.4.0",
+        "@lvce-editor/search-process": "15.3.0",
+        "@lvce-editor/typescript-compile-process": "5.6.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
@@ -2908,9 +2900,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.93.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.16.tgz",
-      "integrity": "sha512-LXoMk4ldjMrlXLALmud4dw6N7hP6w9KN9D5bBXz0boUFnlU26V7FhS57n/4GYF+Z7GpMopT6UIAFFjrT0OmEzQ==",
+      "version": "0.94.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.12.tgz",
+      "integrity": "sha512-OO8XNuXDqMVU6ShwAxFXUUupqulsEfib4LAoUJbjmuUD1gPFcHcPydkyMhtVSt4ZP37yxKLMn0vj4O1RA9Zi7g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2960,9 +2952,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
-      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.6.0.tgz",
+      "integrity": "sha512-sYPqS7waW8Abz8Itum8voW6kalbv4XiVqEtSzw+ABLHLsU7tvbt/Mvru/lf9rUYLrdSTYMCTuYk6CvfBcUPKVg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -15168,17 +15160,6 @@
         "typescript": "^6.0.3"
       }
     },
-    "packages/git-web/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.39.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.39.0.tgz",
-      "integrity": "sha512-3ojIjE03w8thUcdKB7pbLxmN/V6/NHk2gaaiviUfoeRHI3e1cXVvX/fI1BG73/OXW9sU9KJehqkgepKtaNJU7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.20.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
-    },
     "packages/git-worker": {
       "version": "0.0.0-dev",
       "license": "MIT",
@@ -15302,7 +15283,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/server": "^0.93.16"
+        "@lvce-editor/server": "^0.94.12"
       }
     }
   }

--- a/packages/e2e/src/git.quick-pick-create-branch.ts
+++ b/packages/e2e/src/git.quick-pick-create-branch.ts
@@ -35,7 +35,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Qu
   await QuickPick.setValue('>Git: Create Branch...')
   await QuickPick.selectItem('Git: Create Branch...', { waitUntil: 'quickPick' })
   const input = Locator('input[name="QuickPickInput"][placeholder="Branch name"]')
-  await expect(input).toHaveAttribute('placeholder', 'Branch name')
+  await expect(input).toBeVisible()
   await expect(input).toBeFocused()
   await input.type(branchName)
   await expect(input).toHaveValue(branchName)

--- a/packages/e2e/src/git.status-bar-sync.ts
+++ b/packages/e2e/src/git.status-bar-sync.ts
@@ -2,9 +2,10 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.status-bar-sync'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar, Workspace }) => {
+export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const upstreamDir = `${tmpDir}/upstream`
   const workspaceDir = `${tmpDir}/workspace`
 
   await Workspace.setPath(tmpDir)
@@ -17,6 +18,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar
   const syncStatusBarItem = Locator(`${branchStatusBarItem} + .StatusBarItem[name="git.sync"]`)
   await expect(syncStatusBarItem).toBeVisible()
   await expect(syncStatusBarItem).toHaveText('1↓ 1↑')
+  await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Pull 1 and push 1 commits between origin/main')
   await expect(syncStatusBarItem.locator('.MaskIconSync')).toBeVisible()
 
   // act
@@ -27,4 +29,31 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar
   await FileSystem.shouldHaveFile(`${workspaceDir}/remote-file.txt`, 'remote change')
   await FileSystem.shouldHaveFile(`${workspaceDir}/local-file.txt`, 'local change')
   await expect(syncStatusBarItem).toHaveText('0↓ 0↑')
+  await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Synchronize Changes')
+
+  // arrange an outgoing-only change
+  await FileSystem.writeFile(`${workspaceDir}/outgoing.txt`, 'outgoing change')
+  await Git.add('outgoing.txt')
+  await Git.commit('Outgoing change')
+  await Workspace.setPath(tmpDir)
+  await Workspace.setPath(workspaceDir)
+
+  // assert
+  await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Push 1 commits to origin/main')
+
+  // arrange an incoming-only change
+  await Command.execute('ExtensionHost.executeCommand', 'git.push', {})
+  await Workspace.setPath(upstreamDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.pull', {})
+  await FileSystem.writeFile(`${upstreamDir}/incoming.txt`, 'incoming change')
+  await Git.add('incoming.txt')
+  await Git.commit('Incoming change')
+  await Command.execute('ExtensionHost.executeCommand', 'git.push', {})
+  await Workspace.setPath(workspaceDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.fetch')
+  await Workspace.setPath(tmpDir)
+  await Workspace.setPath(workspaceDir)
+
+  // assert
+  await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Pull 1 commits from origin/main')
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -9,7 +9,24 @@
   "scripts": {
     "#test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --detectOpenHandles --forceExit",
     "#test:watch": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --watch",
-    "build-min": "microbundle --entry src/gitMain.ts --output distmin --format modern"
+    "build-min": "microbundle --entry src/gitMain.ts --output distmin --format modern",
+    "test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --runInBand test/UiSourceControlProviderGit.test.ts"
+  },
+  "jest": {
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
+    }
   },
   "devDependencies": {
     "@lvce-editor/api": "^8.61.0",

--- a/packages/extension/src/parts/GetSyncAriaLabel/GetSyncAriaLabel.ts
+++ b/packages/extension/src/parts/GetSyncAriaLabel/GetSyncAriaLabel.ts
@@ -1,0 +1,17 @@
+const getActionLabel = (incoming: number, outgoing: number, upstream: string): string => {
+  if (incoming && outgoing) {
+    return `Pull ${incoming} and push ${outgoing} commits between ${upstream}`
+  }
+  if (incoming) {
+    return `Pull ${incoming} commits from ${upstream}`
+  }
+  if (outgoing) {
+    return `Push ${outgoing} commits to ${upstream}`
+  }
+  return 'Synchronize Changes'
+}
+
+export const getSyncAriaLabel = (repositoryName: string, incoming: number, outgoing: number, upstream: string, spinning: boolean): string => {
+  const actionLabel = spinning ? 'Synchronizing Changes...' : getActionLabel(incoming, outgoing, upstream)
+  return `${repositoryName} (Git) - ${actionLabel}`
+}

--- a/packages/extension/src/parts/IsActive/IsActive.ts
+++ b/packages/extension/src/parts/IsActive/IsActive.ts
@@ -1,0 +1,58 @@
+const supportedSchemes = ['file', '', 'memfs']
+
+export interface IsActiveDependencies {
+  readonly clearCheckout: () => Promise<void>
+  readonly clearSync: () => Promise<void>
+  readonly execute: (
+    command: string,
+    args: readonly string[],
+    options: { readonly cwd: string; readonly reject: boolean },
+  ) => Promise<{ readonly exitCode: number }>
+  readonly refreshCheckout: (root: string) => Promise<void>
+  readonly refreshSync: (root: string) => Promise<void>
+}
+
+export const createIsActive = (dependencies: IsActiveDependencies) => {
+  const state = {
+    latestRequest: 0,
+  }
+
+  const clearStatusBars = async (): Promise<void> => {
+    await dependencies.clearCheckout()
+    await dependencies.clearSync()
+  }
+
+  return async (scheme: string, root?: string): Promise<boolean> => {
+    if (!root || !supportedSchemes.includes(scheme)) {
+      state.latestRequest += 1
+      await clearStatusBars()
+      return false
+    }
+    state.latestRequest += 1
+    const requestId = state.latestRequest
+    try {
+      const { exitCode } = await dependencies.execute('git', ['rev-parse', '--git-dir'], {
+        cwd: root,
+        reject: false,
+      })
+      const isGitRepository = exitCode === 0
+      if (requestId !== state.latestRequest) {
+        return isGitRepository
+      }
+      if (isGitRepository) {
+        await dependencies.refreshCheckout(root)
+        await dependencies.refreshSync(root)
+      } else {
+        await clearStatusBars()
+      }
+      return isGitRepository
+    } catch (error) {
+      if (requestId !== state.latestRequest) {
+        return false
+      }
+      console.log({ error })
+      await clearStatusBars()
+      return false
+    }
+  }
+}

--- a/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
+++ b/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
@@ -1,5 +1,6 @@
 import { registerStatusBarItemProvider } from '@lvce-editor/api'
 import * as CommandId from '../CommandId/CommandId.ts'
+import * as GetSyncAriaLabel from '../GetSyncAriaLabel/GetSyncAriaLabel.ts'
 import * as GitWorker from '../GitWorker/GitWorker.ts'
 import * as GitWorkerCommandType from '../GitWorkerCommandType/GitWorkerCommandType.ts'
 
@@ -8,20 +9,34 @@ const providerId = 'git.sync'
 interface GitUpstreamChanges {
   readonly incoming: number
   readonly outgoing: number
+  readonly upstream: string
 }
 
 const state: {
   handle: undefined | { refresh(): Promise<void> }
   incoming: number
   outgoing: number
+  repositoryName: string
   spinning: boolean
+  upstream: string
   visible: boolean
 } = {
   handle: undefined,
   incoming: 0,
   outgoing: 0,
+  repositoryName: '',
   spinning: false,
+  upstream: '',
   visible: false,
+}
+
+const getRepositoryName = (cwd: string): string => {
+  let normalizedCwd = cwd
+  while (normalizedCwd.endsWith('/') || normalizedCwd.endsWith('\\')) {
+    normalizedCwd = normalizedCwd.slice(0, -1)
+  }
+  const separatorIndex = Math.max(normalizedCwd.lastIndexOf('/'), normalizedCwd.lastIndexOf('\\'))
+  return decodeURIComponent(normalizedCwd.slice(separatorIndex + 1))
 }
 
 const getStatusBarItem = () => {
@@ -29,6 +44,7 @@ const getStatusBarItem = () => {
     return undefined
   }
   return {
+    ariaLabel: GetSyncAriaLabel.getSyncAriaLabel(state.repositoryName, state.incoming, state.outgoing, state.upstream, state.spinning),
     icon: 'MaskIconSync',
     name: CommandId.GitSync,
     onClick: CommandId.GitSync,
@@ -47,6 +63,8 @@ export const initialize = (): void => {
 export const clear = async (): Promise<void> => {
   state.incoming = 0
   state.outgoing = 0
+  state.repositoryName = ''
+  state.upstream = ''
   state.visible = false
   await state.handle?.refresh()
 }
@@ -57,6 +75,9 @@ export const setSpinning = async (spinning: boolean): Promise<void> => {
 }
 
 export const refresh = async (cwd?: string): Promise<void> => {
+  if (cwd) {
+    state.repositoryName = getRepositoryName(cwd)
+  }
   let branch: string
   try {
     branch = await GitWorker.invoke(GitWorkerCommandType.GitGetCurrentBranch, { cwd })
@@ -73,9 +94,11 @@ export const refresh = async (cwd?: string): Promise<void> => {
     const changes: GitUpstreamChanges = await GitWorker.invoke(GitWorkerCommandType.GitGetUpstreamChanges, { cwd })
     state.incoming = changes.incoming
     state.outgoing = changes.outgoing
+    state.upstream = changes.upstream
   } catch {
     state.incoming = 0
     state.outgoing = 0
+    state.upstream = ''
   }
   await state.handle?.refresh()
 }

--- a/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
+++ b/packages/extension/src/parts/UiSourceControlProvider/UiSourceControlProviderGit.ts
@@ -7,6 +7,7 @@ import * as GetChangedFiles from '../GetChangedFiles/GetChangedFiles.ts'
 import * as GetFileBefore from '../GetFileBefore/GetFileBefore.ts'
 import * as GetGroups from '../GetGroups/GetGroups.ts'
 import * as GetDecorations from '../GetDecorations/GetDecorations.ts'
+import * as IsActive from '../IsActive/IsActive.ts'
 import * as StatusBarCheckout from '../StatusBarCheckout/StatusBarCheckout.ts'
 import * as StatusBarSync from '../StatusBarSync/StatusBarSync.ts'
 
@@ -20,40 +21,13 @@ export const add = CommandAdd.execute
 
 export const discard = CommandAdd.execute
 
-const supportedSchemes = ['file', '', 'memfs']
-
-export const isActive = async (scheme, root) => {
-  if (!root) {
-    await StatusBarCheckout.clear()
-    await StatusBarSync.clear()
-    return false
-  }
-  if (!supportedSchemes.includes(scheme)) {
-    await StatusBarCheckout.clear()
-    await StatusBarSync.clear()
-    return false
-  }
-  try {
-    const { exitCode } = await Exec.exec('git', ['rev-parse', '--git-dir'], {
-      cwd: root,
-      reject: false,
-    })
-    const isGitRepository = exitCode === 0
-    if (isGitRepository) {
-      await StatusBarCheckout.refresh(root)
-      await StatusBarSync.refresh(root)
-    } else {
-      await StatusBarCheckout.clear()
-      await StatusBarSync.clear()
-    }
-    return isGitRepository
-  } catch (error) {
-    console.log({ error })
-    await StatusBarCheckout.clear()
-    await StatusBarSync.clear()
-    return false
-  }
-}
+export const isActive = IsActive.createIsActive({
+  clearCheckout: StatusBarCheckout.clear,
+  clearSync: StatusBarSync.clear,
+  execute: Exec.exec,
+  refreshCheckout: StatusBarCheckout.refresh,
+  refreshSync: StatusBarSync.refresh,
+})
 
 export const getBadgeCount = GetBadgeCount.getBadgeCount
 

--- a/packages/extension/test/UiSourceControlProviderGit.test.ts
+++ b/packages/extension/test/UiSourceControlProviderGit.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { createIsActive, type IsActiveDependencies } from '../src/parts/IsActive/IsActive.ts'
+
+const execute = jest.fn<IsActiveDependencies['execute']>()
+const clearCheckout = jest.fn<IsActiveDependencies['clearCheckout']>()
+const refreshCheckout = jest.fn<IsActiveDependencies['refreshCheckout']>()
+const clearSync = jest.fn<IsActiveDependencies['clearSync']>()
+const refreshSync = jest.fn<IsActiveDependencies['refreshSync']>()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('a stale repository check does not clear the current repository status items', async () => {
+  const { promise: staleResult, resolve: resolveStaleResult } = Promise.withResolvers<{ exitCode: number }>()
+  const { promise: currentResult, resolve: resolveCurrentResult } = Promise.withResolvers<{ exitCode: number }>()
+  execute.mockReturnValueOnce(staleResult).mockReturnValueOnce(currentResult)
+  const isActive = createIsActive({
+    clearCheckout,
+    clearSync,
+    execute,
+    refreshCheckout,
+    refreshSync,
+  })
+
+  const staleCheck = isActive('file', '/tmp')
+  const currentCheck = isActive('file', '/tmp/workspace')
+
+  resolveCurrentResult({ exitCode: 0 })
+  await currentCheck
+  resolveStaleResult({ exitCode: 128 })
+  await staleCheck
+
+  expect(refreshCheckout).toHaveBeenCalledWith('/tmp/workspace')
+  expect(refreshSync).toHaveBeenCalledWith('/tmp/workspace')
+  expect(clearCheckout).not.toHaveBeenCalled()
+  expect(clearSync).not.toHaveBeenCalled()
+})

--- a/packages/git-requests/src/parts/GitRequestsGetUpstreamChanges/GitRequestsGetUpstreamChanges.ts
+++ b/packages/git-requests/src/parts/GitRequestsGetUpstreamChanges/GitRequestsGetUpstreamChanges.ts
@@ -4,20 +4,28 @@ import { GitError } from '../GitError/GitError.ts'
 export interface GitUpstreamChanges {
   readonly incoming: number
   readonly outgoing: number
+  readonly upstream: string
 }
 
 export const getUpstreamChanges = async ({ cwd, exec, gitPath }: GitRequestContext): Promise<GitUpstreamChanges> => {
   try {
-    const gitResult = await exec({
+    const changesResult = await exec({
       args: ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
       cwd,
       gitPath,
       name: 'getUpstreamChanges',
     })
-    const [outgoing = 0, incoming = 0] = gitResult.stdout.trim().split(/\s+/).map(Number)
+    const upstreamResult = await exec({
+      args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      cwd,
+      gitPath,
+      name: 'getUpstreamChanges',
+    })
+    const [outgoing = 0, incoming = 0] = changesResult.stdout.trim().split(/\s+/).map(Number)
     return {
       incoming,
       outgoing,
+      upstream: upstreamResult.stdout.trim(),
     }
   } catch (error) {
     throw new GitError(error, 'getUpstreamChanges')

--- a/packages/git-requests/test/GitRequestsGetUpstreamChanges.test.ts
+++ b/packages/git-requests/test/GitRequestsGetUpstreamChanges.test.ts
@@ -3,10 +3,18 @@ import type { GitExec } from '../src/parts/Types/Types.ts'
 import * as GitRequestsGetUpstreamChanges from '../src/parts/GitRequestsGetUpstreamChanges/GitRequestsGetUpstreamChanges.ts'
 
 test('getUpstreamChanges', async (): Promise<void> => {
-  const exec = jest.fn<GitExec>(async () => ({
-    stderr: '',
-    stdout: '2\t3\n',
-  }))
+  const exec = jest.fn<GitExec>(async ({ args }) => {
+    if (args[0] === 'rev-list') {
+      return {
+        stderr: '',
+        stdout: '2\t3\n',
+      }
+    }
+    return {
+      stderr: '',
+      stdout: 'origin/main\n',
+    }
+  })
 
   await expect(
     GitRequestsGetUpstreamChanges.getUpstreamChanges({
@@ -17,9 +25,16 @@ test('getUpstreamChanges', async (): Promise<void> => {
   ).resolves.toEqual({
     incoming: 3,
     outgoing: 2,
+    upstream: 'origin/main',
   })
-  expect(exec).toHaveBeenCalledWith({
+  expect(exec).toHaveBeenNthCalledWith(1, {
     args: ['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'],
+    cwd: '/test/workspace',
+    gitPath: '/test/git',
+    name: 'getUpstreamChanges',
+  })
+  expect(exec).toHaveBeenNthCalledWith(2, {
+    args: ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
     cwd: '/test/workspace',
     gitPath: '/test/git',
     name: 'getUpstreamChanges',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/server": "^0.93.16"
+    "@lvce-editor/server": "^0.94.12"
   }
 }


### PR DESCRIPTION
Adds VS Code-style Git sync aria labels using the repository name, actual tracked upstream, and incoming/outgoing counts.

Covers diverged, clean, outgoing-only, and incoming-only states end to end. The e2e server dependency is updated to the first LVCE runtime containing extension-provided status-bar aria-label support.