### PR TITLE
test: enable git branch picker icon coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,9 +2183,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.13.1.tgz",
-      "integrity": "sha512-EeadpDQ6hHpJc5OEOSo5Y50ymlYOyltwgYhkZ2c5RtjbYjgwgI4IT7cF9cX4QMaano5/F59IuAsrGKW0OnXabQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.14.0.tgz",
+      "integrity": "sha512-iryFo2ewCtq4l4j1TZN3FAAjYDROu3fg/pOLA2gID9Sbbjwoaedj/Q3lxTQ/yBmGOtjo0ykVLKCyZjqGBSvPXA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2314,9 +2314,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.94.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.12.tgz",
-      "integrity": "sha512-cZ+dxNic8snmLePnqzZ4s/VyysZfz5BIEk8+s3fTT3yxf9Bdy40gQ2P90sPpJo/6cPc/XhMS+fWCR+a7nPWYRg==",
+      "version": "0.94.16",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.16.tgz",
+      "integrity": "sha512-kvaMkpuL0qAPitkV85HtusbzIstAtWOmnpu6DpX9un4bD3Uu6oTSqguC4iL931HzybK+otyhsVBVE7F0+4TJXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2451,9 +2451,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/network-process/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2843,14 +2843,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.94.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.12.tgz",
-      "integrity": "sha512-H5Q/dTCF1BMxh5VUhabwDGD3+ew8H6sHPGa3QyD/qx72jEIiGSH3MUN0Be06kxI/cHKX7uprPBd03k+weTeNjA==",
+      "version": "0.94.16",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.16.tgz",
+      "integrity": "sha512-giG/FYlTZ/30MFwUwyAObKVSi6WAOoRgw5bQAN6pX5o6IMtGrPGdqFvUv5wKAQB2CYxkdUCT5PttsPLFoiL7OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.94.12",
-        "@lvce-editor/static-server": "0.94.12"
+        "@lvce-editor/shared-process": "0.94.16",
+        "@lvce-editor/static-server": "0.94.16"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2860,15 +2860,15 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.94.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.12.tgz",
-      "integrity": "sha512-qJDiVUudpTG/01EKuHedEvdAUTDvfff2x3qLornjmhq4qpVlRv8Kk7oyaBEZh4EzPHfi26+UQQVaABB2cHc7YA==",
+      "version": "0.94.16",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.16.tgz",
+      "integrity": "sha512-TO4TbifsQNfm3FKh0GKT6XTPxgiFedYpCBRvCKxE2jAyfQswGtPI0BvyfOxfqvn6JDM2ShiUXed1gzIIdbK9ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.12.0",
-        "@lvce-editor/extension-host-helper-process": "0.94.12",
+        "@lvce-editor/extension-host-helper-process": "0.94.16",
         "@lvce-editor/ipc": "16.6.0",
         "@lvce-editor/json-rpc": "8.5.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2884,7 +2884,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.13.1",
+        "@lvce-editor/embeds-process": "4.14.0",
         "@lvce-editor/file-system-process": "5.7.0",
         "@lvce-editor/file-watcher-process": "4.9.0",
         "@lvce-editor/network-process": "5.2.0",
@@ -2900,9 +2900,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.94.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.12.tgz",
-      "integrity": "sha512-OO8XNuXDqMVU6ShwAxFXUUupqulsEfib4LAoUJbjmuUD1gPFcHcPydkyMhtVSt4ZP37yxKLMn0vj4O1RA9Zi7g==",
+      "version": "0.94.16",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.16.tgz",
+      "integrity": "sha512-LCcg0qncvVXMHkVzmdAhT3izxHmovyqi0ntR/yBtAWlIJTsKTJxb+DeaMMGVgkgdBUoAqtLsf6BIzFg5GXE3xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15283,7 +15283,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/server": "^0.94.12"
+        "@lvce-editor/server": "^0.94.16"
       }
     }
   }

--- a/packages/e2e/src/git.branch-picker-action-icons.ts
+++ b/packages/e2e/src/git.branch-picker-action-icons.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.branch-picker-action-icons'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPick, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })

--- a/packages/e2e/src/git.branch-picker-local-icon.ts
+++ b/packages/e2e/src/git.branch-picker-local-icon.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.branch-picker-local-icon'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPick, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })

--- a/packages/e2e/src/git.branch-picker-remote-icon.ts
+++ b/packages/e2e/src/git.branch-picker-remote-icon.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.branch-picker-remote-icon'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, QuickPick, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/server": "^0.94.12"
+    "@lvce-editor/server": "^0.94.16"
   }
 }


### PR DESCRIPTION
## Summary

Updates the packaged editor test runtime and enables end-to-end coverage for branch picker action, local branch, and remote cloud icons.