### PR TITLE
fix: hide zero git sync counts

### DIFF
--- a/packages/e2e/src/git.status-bar-sync.ts
+++ b/packages/e2e/src/git.status-bar-sync.ts
@@ -28,7 +28,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Si
   // assert
   await FileSystem.shouldHaveFile(`${workspaceDir}/remote-file.txt`, 'remote change')
   await FileSystem.shouldHaveFile(`${workspaceDir}/local-file.txt`, 'local change')
-  await expect(syncStatusBarItem).toHaveText('0↓ 0↑')
+  await expect(syncStatusBarItem).toHaveText('')
   await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Synchronize Changes')
 
   // arrange an outgoing-only change
@@ -39,6 +39,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Si
   await Workspace.setPath(workspaceDir)
 
   // assert
+  await expect(syncStatusBarItem).toHaveText('1↑')
   await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Push 1 commits to origin/main')
 
   // arrange an incoming-only change
@@ -55,5 +56,6 @@ export const test: Test = async ({ Command, expect, FileSystem, Git, Locator, Si
   await Workspace.setPath(workspaceDir)
 
   // assert
+  await expect(syncStatusBarItem).toHaveText('1↓')
   await expect(syncStatusBarItem).toHaveAttribute('aria-label', 'workspace (Git) - Pull 1 commits from origin/main')
 }

--- a/packages/extension/src/parts/GetSyncText/GetSyncText.ts
+++ b/packages/extension/src/parts/GetSyncText/GetSyncText.ts
@@ -1,0 +1,10 @@
+export const getSyncText = (incoming: number, outgoing: number): string => {
+  const parts: string[] = []
+  if (incoming) {
+    parts.push(`${incoming}↓`)
+  }
+  if (outgoing) {
+    parts.push(`${outgoing}↑`)
+  }
+  return parts.join(' ')
+}

--- a/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
+++ b/packages/extension/src/parts/StatusBarSync/StatusBarSync.ts
@@ -1,6 +1,7 @@
 import { registerStatusBarItemProvider } from '@lvce-editor/api'
 import * as CommandId from '../CommandId/CommandId.ts'
 import * as GetSyncAriaLabel from '../GetSyncAriaLabel/GetSyncAriaLabel.ts'
+import * as GetSyncText from '../GetSyncText/GetSyncText.ts'
 import * as GitWorker from '../GitWorker/GitWorker.ts'
 import * as GitWorkerCommandType from '../GitWorkerCommandType/GitWorkerCommandType.ts'
 
@@ -49,7 +50,7 @@ const getStatusBarItem = () => {
     name: CommandId.GitSync,
     onClick: CommandId.GitSync,
     spinning: state.spinning,
-    text: `${state.incoming}↓ ${state.outgoing}↑`,
+    text: GetSyncText.getSyncText(state.incoming, state.outgoing),
   }
 }
 

--- a/packages/extension/test/GetSyncText.test.ts
+++ b/packages/extension/test/GetSyncText.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@jest/globals'
+import * as GetSyncText from '../src/parts/GetSyncText/GetSyncText.ts'
+
+test('returns an empty string when there are no incoming or outgoing changes', () => {
+  expect(GetSyncText.getSyncText(0, 0)).toBe('')
+})
+
+test('returns only incoming changes when outgoing changes are zero', () => {
+  expect(GetSyncText.getSyncText(1, 0)).toBe('1↓')
+})
+
+test('returns only outgoing changes when incoming changes are zero', () => {
+  expect(GetSyncText.getSyncText(0, 1)).toBe('1↑')
+})
+
+test('returns both incoming and outgoing changes when both are non-zero', () => {
+  expect(GetSyncText.getSyncText(1, 2)).toBe('1↓ 2↑')
+})


### PR DESCRIPTION
Hide zero-valued incoming and outgoing counts from the Git sync status bar item while keeping non-zero counts visible. Includes focused formatter coverage and updates the existing status bar sync e2e scenario.