### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,12 +2141,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.61.0.tgz",
-      "integrity": "sha512-lAYmT0vTwuoWN+m27t+DvrzmtYjUL8gyyy0pUsObOmia8dZHmUV3vhzgWfMaafKRJvAHpal78aqHsAgbBw1XUw==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -15095,7 +15096,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^8.61.0",
+        "@lvce-editor/api": "^8.75.0",
         "execa": "^9.6.1",
         "jest-environment-lvce-editor": "^0.70.8"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^8.61.0",
+    "@lvce-editor/api": "^8.75.0",
     "execa": "^9.6.1",
     "jest-environment-lvce-editor": "^0.70.8"
   }


### PR DESCRIPTION
Updates the extension API dependency to 8.75.0 so unused API commands can be tree-shaken from the production bundle.\n\nMeasured extension main output: 109,617 → 79,475 bytes (−30,142); extension.tar.br: 74,691 → 70,061 bytes (−4,630).