### PR TITLE
fix: use scoped node rpc for git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.75.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
-      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
+      "version": "8.78.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.78.0.tgz",
+      "integrity": "sha512-6BzLqCgy7U02psWk6c83Z4Qo62C2UnLTGnE7xaIRqJbh1j0cLQ4EK6agJsCoqENjtGKFmvRhtHBH4/G/wMzISQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15057,7 +15057,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^8.75.0",
+        "@lvce-editor/api": "^8.78.0",
         "execa": "^9.6.1",
         "jest-environment-lvce-editor": "^0.70.8"
       }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/buildNodeClient.test.js"
+    "test": "node --test test/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/packages/build/test/buildExtension.test.js
+++ b/packages/build/test/buildExtension.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { bundleJs } from '@lvce-editor/package-extension'
+import { root } from '../src/root.ts'
+
+test('uses the scoped node rpc command', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'builtin-git-extension-'))
+  try {
+    const outFile = join(temporaryDirectory, 'gitMain.js')
+    await bundleJs(join(root, 'packages', 'extension', 'src', 'gitMain.ts'), outFile, false)
+
+    const bundle = await readFile(outFile, 'utf8')
+
+    assert.match(bundle, /Extensions\.createNodeRpcConnection/)
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true })
+  }
+})

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^8.75.0",
+    "@lvce-editor/api": "^8.78.0",
     "execa": "^9.6.1",
     "jest-environment-lvce-editor": "^0.70.8"
   }


### PR DESCRIPTION
Update the Git extension API so isolated Git activation uses the extension-scoped Node RPC connection exposed by extension-management-worker. Add a bundle regression test that prevents returning to the deprecated Node RPC lookup.