### PR TITLE
Update LVCE Editor server to 0.96.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2797,9 +2797,9 @@
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.11.0.tgz",
-      "integrity": "sha512-leUPrcdEfO1aYA7KCfQJdJ/Rji6FCN+M6yqOin0i81wXukdRl66qdGYoXO8eBIpCy2eAAgAMc89S2iw8aOeFfw==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.7.0.tgz",
+      "integrity": "sha512-Ek8ZOHYLzJ5nRAyv4WFT2BCofsjqAckAcD17GkAKiwa5rH0C+GPiq0MtT9yGBoObdsida7OSocEddRrPSYtErg==",
       "dev": true,
       "license": "MIT"
     },
@@ -14893,7 +14893,6 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/static-server": "0.96.19",
         "@lvce-editor/test-with-playwright": "^22.11.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,9 +2282,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.12.tgz",
-      "integrity": "sha512-ERncFru8iwPAn8xHjHYBXnyOlDL5RU4uUbKFqCkvhfCG8v2Anmz1ilPK25kQxKXUAdTY7hzX5yylgeCACzH5DA==",
+      "version": "0.96.19",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.19.tgz",
+      "integrity": "sha512-SRcZm4hq0J+OciOxrhPZEpdVSXlqzHXGYUMvaNGXN72Xj43Jma2+cF+TIYqWsbX2JdFFpaxngkxXfD3VamI1Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2731,14 +2731,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.12.tgz",
-      "integrity": "sha512-XHvSr501fv/0MIbJXSzIMrLDq4djzRaLlHewKMlGtr57/Btz/atqVeb5g8wbsLS+HLdd9hQOVZM1LrGEvaHiRA==",
+      "version": "0.96.19",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.19.tgz",
+      "integrity": "sha512-MRJpvLx14tks7cJyxscgXaLqE6I5og1onZgFE5a4u/XK9cDGqoRd6IEBCA9SGBRDO2FUcxr6ftCEMVcrqbu7ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.96.12",
-        "@lvce-editor/static-server": "0.96.12"
+        "@lvce-editor/shared-process": "0.96.19",
+        "@lvce-editor/static-server": "0.96.19"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2748,14 +2748,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.12.tgz",
-      "integrity": "sha512-ZdyOoNfEaHYPPEYDSuoKuMr9waXTzLwrAHxKj/sC27L9oLzP/CL2HW7iQosJRorTwTtfpm9l/k3y7KYrR8M6Tg==",
+      "version": "0.96.19",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.19.tgz",
+      "integrity": "sha512-ggbr/bq1hONBOidoLq4/TCfTuwmt/XfdCv82jZma9KSDn/xeRhyuQJO/Y7gSU1wmAiXNlOugvpeisvSBF0GaPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.96.12",
+        "@lvce-editor/extension-host-helper-process": "0.96.19",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2787,54 +2787,19 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.96.12",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.12.tgz",
-      "integrity": "sha512-9hMcQbGGTJYknInPdjetwMT9lUe2n/nyAfoPM0rylzh9h1Is7FcQXdot+XQKz8Zx45j344niQC+z+O1nCZfwnw==",
+      "version": "0.96.19",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.19.tgz",
+      "integrity": "sha512-7GmhhrcCLDK6ZbB/ss3PVWrn/096BzPib+vxkbbTsox0zWpBuzwytfMV4rdtH4bSoVIvJPTgpWfxo185VjZVBw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.12.0.tgz",
-      "integrity": "sha512-sEABqKqEvo6dkq3Qt3dlr/oKSIz/M5RrQ1aMPdGiCX3qzZY2CSvuhQ0WRR4NdEBZxxUd+qElDGO95u0xglOW3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.12.0",
-        "@lvce-editor/test-worker": "^17.6.2"
-      },
-      "bin": {
-        "test-with-playwright": "bin/test-with-playwright.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.12.0.tgz",
-      "integrity": "sha512-xrm1+/y60/e3e82M/+UpElHufGrtSavztiM7Tj+30v7DOr4xAjKUEDpKLC11CKaR3KoSllP6HCuy9O3B/xJGyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@playwright/test": "1.61.1",
-        "get-port": "^7.2.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "v8-to-istanbul": "^9.3.0"
-      },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.7.0.tgz",
-      "integrity": "sha512-Ek8ZOHYLzJ5nRAyv4WFT2BCofsjqAckAcD17GkAKiwa5rH0C+GPiq0MtT9yGBoObdsida7OSocEddRrPSYtErg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.11.0.tgz",
+      "integrity": "sha512-leUPrcdEfO1aYA7KCfQJdJ/Rji6FCN+M6yqOin0i81wXukdRl66qdGYoXO8eBIpCy2eAAgAMc89S2iw8aOeFfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11693,19 +11658,6 @@
         "fsevents": "2.3.2"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -11719,6 +11671,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -14928,7 +14893,43 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
+        "@lvce-editor/static-server": "0.96.19",
         "@lvce-editor/test-with-playwright": "^22.11.0"
+      }
+    },
+    "packages/e2e/node_modules/@lvce-editor/test-with-playwright": {
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.12.0.tgz",
+      "integrity": "sha512-sEABqKqEvo6dkq3Qt3dlr/oKSIz/M5RrQ1aMPdGiCX3qzZY2CSvuhQ0WRR4NdEBZxxUd+qElDGO95u0xglOW3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/test-with-playwright-worker": "22.12.0",
+        "@lvce-editor/test-worker": "^17.6.2"
+      },
+      "bin": {
+        "test-with-playwright": "bin/test-with-playwright.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "packages/e2e/node_modules/@lvce-editor/test-with-playwright-worker": {
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.12.0.tgz",
+      "integrity": "sha512-xrm1+/y60/e3e82M/+UpElHufGrtSavztiM7Tj+30v7DOr4xAjKUEDpKLC11CKaR3KoSllP6HCuy9O3B/xJGyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@playwright/test": "1.61.1",
+        "get-port": "^7.2.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "v8-to-istanbul": "^9.3.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "packages/extension": {
@@ -15090,7 +15091,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/server": "^0.96.12"
+        "@lvce-editor/server": "^0.96.19"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2109,7 +2109,8 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@lvce-editor/api": {
       "version": "8.78.0",
@@ -2125,23 +2126,10 @@
       }
     },
     "node_modules/@lvce-editor/assert": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
-      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
-    },
-    "node_modules/@lvce-editor/auth-process": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.12.0.tgz",
-      "integrity": "sha512-lLA01IwXTKdTWXg1ydpsdjHilY3LDT6Ud5DWWaZ6uPwmhTeSIpQ5BP+Fu+8hlZYMW4gUyuFtuYjtDV88S5dF4A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "auth-process": "bin/oauthProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
@@ -2150,15 +2138,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.23.0.tgz",
-      "integrity": "sha512-hjkqo7QLQl7pL2c+rH54q0/8dSpKDSfF6/3BvBAS2NsSpvtCnab3Ew4bhVyMJrw1c9RnwcC2pmy6iDPtPpz0IQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
+      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.14.0.tgz",
-      "integrity": "sha512-iryFo2ewCtq4l4j1TZN3FAAjYDROu3fg/pOLA2gID9Sbbjwoaedj/Q3lxTQ/yBmGOtjo0ykVLKCyZjqGBSvPXA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2294,27 +2282,25 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.94.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.16.tgz",
-      "integrity": "sha512-kvaMkpuL0qAPitkV85HtusbzIstAtWOmnpu6DpX9un4bD3Uu6oTSqguC4iL931HzybK+otyhsVBVE7F0+4TJXg==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.12.tgz",
+      "integrity": "sha512-ERncFru8iwPAn8xHjHYBXnyOlDL5RU4uUbKFqCkvhfCG8v2Anmz1ilPK25kQxKXUAdTY7hzX5yylgeCACzH5DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.12.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.1",
-        "got": "^15.1.0",
-        "minimist": "^1.2.8"
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.7.0.tgz",
-      "integrity": "sha512-tA0GKQ1xwl38YivgPLbCfaYQ/D+EUzL9xn2sOp0yc9imIz6Tf49acI0jLD0/iAodbqeBX6EzjSWRXqXnpa4ygg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
+      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2330,9 +2316,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.9.0.tgz",
-      "integrity": "sha512-bAJwrxnjiLL2Wb/saGDyVg1Rh+fDpBBuFqzTCOkMu4X8J8EZZ+rE1D2/K59lSL868wgsUSMNBE8AWzGLawkUsQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2356,23 +2342,24 @@
       "link": true
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.6.0.tgz",
-      "integrity": "sha512-DYP2n651sgxPq6ovBDsuKFo+SnuS6/ipEH64DZGFaBjNJ+PFUrUHq+5gZiUgBM9GifGkyTKFSGL7eq4K5/EETg==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.5.0.tgz",
-      "integrity": "sha512-cBL4jq/DFnbZdyFMk/+nhb3+e4fEPrtyHt0eKPcWb/cauBH5cbju1fwEfmDcT+8oA44ILcF2NoqZ7jnuEeFRgQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -2408,20 +2395,6 @@
         "open": "^10.1.2"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/@sindresorhus/is": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2431,9 +2404,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/network-process/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2484,34 +2457,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/got": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
-      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/is": "^7.0.1",
-        "byte-counter": "^0.1.0",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.12",
-        "decompress-response": "^10.0.0",
-        "form-data-encoder": "^4.0.2",
-        "http2-wrapper": "^2.2.1",
-        "keyv": "^5.5.3",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^4.0.1",
-        "responselike": "^4.0.2",
-        "type-fest": "^4.26.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -2519,31 +2464,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@lvce-editor/network-process/node_modules/minimatch": {
       "version": "3.1.5",
@@ -2652,20 +2572,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/wsl-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
@@ -2733,9 +2639,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.1.tgz",
-      "integrity": "sha512-C5K/24ThaIoYRq30hBk0jXAtVwQzY2tWNdcbUW72mKNww+EmGhXlHlHA6Cwhz7ae8Q4Dfd9XeekKMBVlNWweTA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2749,12 +2655,15 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.4.0.tgz",
-      "integrity": "sha512-Ka/MkHduJi6N/42FQuA+Qiz41HzmRnuXiyABZTENQi9/HE/Z+PrXQ92RDpSh9El4lrLX0JNMvhnk2EqgqcJw/Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
       "bin": {
         "pty-host": "bin/ptyHost.js"
       },
@@ -2763,9 +2672,9 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.4.0.tgz",
-      "integrity": "sha512-9Y6xyk24MuVwz6WDv9SWyxVC351x1H/yHr2yaU5iuf0snnlGKOX4ix/QpniiESDHjlJn74B2V/h6DI4kwxckkQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.5.0.tgz",
+      "integrity": "sha512-k4VM7TG6/dENvTqiuJJZtSr4x9ZCzCnRsUVZFijVexPSvR0JmHY6MC1gAcLeb13kQbtL/CVJZNJ/sk64JSMSeg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2777,38 +2686,37 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.12.0.tgz",
-      "integrity": "sha512-qLaGwjenfbE/3e2LzOsPJazonyZ9GMHbOdYloBtNtzjdd3mre3lFIuCV4D8prq5P1quFiAlGRlgNCDPhb/G7Bg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.6.0",
+        "@lvce-editor/ipc": "^16.9.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.43.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.43.0.tgz",
-      "integrity": "sha512-STUNoKvOO9D90p2sk3PXJKwVwEGwArBPB33pCImfBg6HrTP2Q/OPZMzi4HXwseNfusOO6xPlaiXKEND1fgwlOw==",
+      "version": "9.47.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
+      "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.23.0",
+        "@lvce-editor/constants": "^5.25.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.3.0.tgz",
-      "integrity": "sha512-HakFxJ2h7rWTFFvD/pEcPE1EPvikQpLooxxYkmqt5YhtWl24xikJGrwl/uGVfrsrqp8o1kEZ6DPVY9nvKRjFRw==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
+      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/constants": "^5.14.0",
         "execa": "^9.6.1",
         "ws": "^8.21.1"
       },
@@ -2823,14 +2731,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.94.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.16.tgz",
-      "integrity": "sha512-giG/FYlTZ/30MFwUwyAObKVSi6WAOoRgw5bQAN6pX5o6IMtGrPGdqFvUv5wKAQB2CYxkdUCT5PttsPLFoiL7OA==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.12.tgz",
+      "integrity": "sha512-XHvSr501fv/0MIbJXSzIMrLDq4djzRaLlHewKMlGtr57/Btz/atqVeb5g8wbsLS+HLdd9hQOVZM1LrGEvaHiRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.94.16",
-        "@lvce-editor/static-server": "0.94.16"
+        "@lvce-editor/shared-process": "0.96.12",
+        "@lvce-editor/static-server": "0.96.12"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2840,39 +2748,38 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.94.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.16.tgz",
-      "integrity": "sha512-TO4TbifsQNfm3FKh0GKT6XTPxgiFedYpCBRvCKxE2jAyfQswGtPI0BvyfOxfqvn6JDM2ShiUXed1gzIIdbK9ig==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.12.tgz",
+      "integrity": "sha512-ZdyOoNfEaHYPPEYDSuoKuMr9waXTzLwrAHxKj/sC27L9oLzP/CL2HW7iQosJRorTwTtfpm9l/k3y7KYrR8M6Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.12.0",
-        "@lvce-editor/extension-host-helper-process": "0.94.16",
-        "@lvce-editor/ipc": "16.6.0",
-        "@lvce-editor/json-rpc": "8.5.0",
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.96.12",
+        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.12.1",
-        "@lvce-editor/rpc-registry": "9.43.0",
+        "@lvce-editor/process-explorer": "3.14.0",
+        "@lvce-editor/rpc-registry": "9.47.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
-        "markdown-it": "^14.3.0",
+        "markdown-it": "^15.0.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.14.0",
-        "@lvce-editor/file-system-process": "5.7.0",
-        "@lvce-editor/file-watcher-process": "4.9.0",
+        "@lvce-editor/embeds-process": "4.15.0",
+        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.4.0",
-        "@lvce-editor/search-process": "15.3.0",
-        "@lvce-editor/typescript-compile-process": "5.6.0",
+        "@lvce-editor/pty-host": "8.7.0",
+        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
@@ -2880,9 +2787,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.94.16",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.16.tgz",
-      "integrity": "sha512-LCcg0qncvVXMHkVzmdAhT3izxHmovyqi0ntR/yBtAWlIJTsKTJxb+DeaMMGVgkgdBUoAqtLsf6BIzFg5GXE3xg==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.12.tgz",
+      "integrity": "sha512-9hMcQbGGTJYknInPdjetwMT9lUe2n/nyAfoPM0rylzh9h1Is7FcQXdot+XQKz8Zx45j344niQC+z+O1nCZfwnw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2932,9 +2839,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.6.0.tgz",
-      "integrity": "sha512-sYPqS7waW8Abz8Itum8voW6kalbv4XiVqEtSzw+ABLHLsU7tvbt/Mvru/lf9rUYLrdSTYMCTuYk6CvfBcUPKVg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4104,13 +4011,14 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
-      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -4254,7 +4162,8 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -6090,6 +5999,7 @@
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -6113,6 +6023,7 @@
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -6123,6 +6034,7 @@
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -6142,6 +6054,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -6258,19 +6171,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chunk-data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
-      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chunkify": {
@@ -6676,6 +6576,7 @@
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -6936,13 +6837,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -8201,27 +8102,28 @@
       "license": "MIT"
     },
     "node_modules/got": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
-      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@sindresorhus/is": "^8.0.0",
+        "@sindresorhus/is": "^7.0.1",
         "byte-counter": "^0.1.0",
         "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.18",
-        "chunk-data": "^0.1.0",
+        "cacheable-request": "^13.0.12",
         "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
         "http2-wrapper": "^2.2.1",
-        "keyv": "^5.6.0",
-        "lowercase-keys": "^4.0.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
         "responselike": "^4.0.2",
-        "type-fest": "^5.6.0",
-        "uint8array-extras": "^1.5.0"
+        "type-fest": "^4.26.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -8233,21 +8135,20 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
+      "optional": true,
       "engines": {
-        "node": ">=20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8340,7 +8241,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
@@ -8348,6 +8250,7 @@
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -9827,9 +9730,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
       "dev": true,
       "funding": [
         {
@@ -9843,7 +9746,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^3.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -9888,13 +9791,14 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
-      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=20"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9985,9 +9889,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
       "dev": true,
       "funding": [
         {
@@ -10001,22 +9905,32 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.5.0",
-        "linkify-it": "^5.0.2",
-        "mdurl": "^2.0.0",
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "uc.micro": "^3.0.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "Python-2.0"
     },
     "node_modules/markdown-table": {
@@ -10994,6 +10908,7 @@
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -11192,6 +11107,7 @@
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -11985,6 +11901,7 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -12141,7 +12058,8 @@
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -12182,24 +12100,12 @@
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
       "engines": {
         "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/responselike/node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12733,19 +12639,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tail": {
@@ -13339,9 +13232,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13357,19 +13250,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbash": {
@@ -15210,7 +15090,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/server": "^0.94.16"
+        "@lvce-editor/server": "^0.96.12"
       }
     }
   }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -6,12 +6,11 @@
   "main": "index.js",
   "scripts": {
     "pree2e": "node ../build/src/build-runtime.ts",
-    "e2e": "node src/run-tests.js",
+    "e2e": "node ../../scripts/run-e2e.js",
     "pree2e:headless": "node ../build/src/build-runtime.ts",
-    "e2e:headless": "node src/run-tests.js --headless"
+    "e2e:headless": "node ../../scripts/run-e2e.js --headless"
   },
   "devDependencies": {
-    "@lvce-editor/static-server": "0.96.19",
     "@lvce-editor/test-with-playwright": "^22.11.0"
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -6,11 +6,12 @@
   "main": "index.js",
   "scripts": {
     "pree2e": "node ../build/src/build-runtime.ts",
-    "e2e": "test-with-playwright --only-extension=../extension --test-path=.",
+    "e2e": "node src/run-tests.js",
     "pree2e:headless": "node ../build/src/build-runtime.ts",
-    "e2e:headless": "test-with-playwright --only-extension=../extension --test-path=. --headless"
+    "e2e:headless": "node src/run-tests.js --headless"
   },
   "devDependencies": {
+    "@lvce-editor/static-server": "0.96.19",
     "@lvce-editor/test-with-playwright": "^22.11.0"
   }
 }

--- a/packages/e2e/src/run-tests.js
+++ b/packages/e2e/src/run-tests.js
@@ -1,0 +1,133 @@
+import { spawn } from 'node:child_process'
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, extname, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+const root = resolve(currentDir, '../../..')
+
+const getStaticServerPaths = async () => {
+  const staticServerPackagePath = fileURLToPath(import.meta.resolve('@lvce-editor/static-server/package.json'))
+  const staticServerRoot = dirname(staticServerPackagePath)
+  const staticRoot = join(staticServerRoot, 'static')
+  const entries = await readdir(staticRoot, { withFileTypes: true })
+  const candidates = []
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    const extensionsPath = join(staticRoot, entry.name, 'extensions')
+    try {
+      if ((await stat(extensionsPath)).isDirectory()) {
+        candidates.push(extensionsPath)
+      }
+    } catch {}
+  }
+  if (candidates.length !== 1) {
+    throw new Error(`Expected one built-in extensions directory, found ${candidates.length}`)
+  }
+  return {
+    builtinExtensionsPath: candidates[0],
+    configPath: join(staticServerRoot, 'config.json'),
+    staticRoot,
+  }
+}
+
+const getFiles = async (path) => {
+  const entries = await readdir(path, { withFileTypes: true })
+  const files = []
+  for (const entry of entries) {
+    const childPath = join(path, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await getFiles(childPath)))
+    } else if (entry.isFile()) {
+      files.push(childPath)
+    }
+  }
+  return files
+}
+
+const addExtensionFilesToStaticConfig = async (configPath, staticRoot, extensionPaths) => {
+  const originalConfig = await readFile(configPath, 'utf8')
+  const config = JSON.parse(originalConfig)
+  const headerIndexByExtension = new Map()
+  const staticFiles = Object.entries(config.files)
+  for (const onlyExtensionFiles of [true, false]) {
+    for (const [path, headerIndex] of staticFiles) {
+      if (path.includes('/extensions/') !== onlyExtensionFiles) {
+        continue
+      }
+      const extension = extname(path)
+      if (extension && !headerIndexByExtension.has(extension)) {
+        headerIndexByExtension.set(extension, headerIndex)
+      }
+    }
+  }
+  for (const extensionPath of extensionPaths) {
+    for (const path of await getFiles(extensionPath)) {
+      const extension = extname(path)
+      const headerIndex = headerIndexByExtension.get(extension)
+      if (headerIndex === undefined) {
+        throw new Error(`No static response headers found for ${extension}`)
+      }
+      const requestPath = '/' + relative(staticRoot, path).split(sep).join('/')
+      config.files[requestPath] = headerIndex
+    }
+  }
+  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n')
+  return originalConfig
+}
+
+const runTests = async (builtinExtensionsPath, builtinExtensionPath) => {
+  const testWithPlaywrightPath = fileURLToPath(import.meta.resolve('@lvce-editor/test-with-playwright/bin/test-with-playwright.js'))
+  const args = [testWithPlaywrightPath, `--only-extension=${builtinExtensionPath}`, '--test-path=.', ...process.argv.slice(2)]
+  const child = spawn(process.execPath, args, {
+    env: {
+      ...process.env,
+      BUILTIN_EXTENSIONS_PATH: builtinExtensionsPath,
+    },
+    stdio: 'inherit',
+  })
+  return new Promise((resolve, reject) => {
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Test process exited with signal ${signal}`))
+        return
+      }
+      resolve(code ?? 1)
+    })
+  })
+}
+
+const main = async () => {
+  const { builtinExtensionsPath, configPath, staticRoot } = await getStaticServerPaths()
+  const builtinExtensionPath = join(builtinExtensionsPath, 'builtin.git')
+  const builtinGitWebPath = join(builtinExtensionsPath, 'git-web')
+  const builtinGitWorkerPath = join(builtinExtensionsPath, 'git-worker')
+  const builtinNodePath = join(builtinExtensionsPath, 'node')
+  let originalConfig = ''
+  try {
+    await mkdir(builtinExtensionPath, { recursive: true })
+    await Promise.all([
+      cp(join(root, 'packages', 'extension', 'dist'), join(builtinExtensionPath, 'dist'), { recursive: true }),
+      cp(join(root, 'packages', 'extension', 'extension.json'), join(builtinExtensionPath, 'extension.json')),
+      cp(join(root, 'packages', 'extension', 'icon.png'), join(builtinExtensionPath, 'icon.png')),
+      cp(join(root, 'packages', 'extension', 'icons'), join(builtinExtensionPath, 'icons'), { recursive: true }),
+      cp(join(root, 'packages', 'git-web', 'dist'), join(builtinGitWebPath, 'dist'), { recursive: true }),
+      cp(join(root, 'packages', 'git-worker', 'dist'), join(builtinGitWorkerPath, 'dist'), { recursive: true }),
+      cp(join(root, 'packages', 'node'), builtinNodePath, { recursive: true }),
+    ])
+    originalConfig = await addExtensionFilesToStaticConfig(configPath, staticRoot, [builtinExtensionPath, builtinGitWebPath, builtinGitWorkerPath])
+    process.exitCode = await runTests(builtinExtensionsPath, builtinExtensionPath)
+  } finally {
+    if (originalConfig) {
+      await writeFile(configPath, originalConfig)
+    }
+    await Promise.all(
+      [builtinExtensionPath, builtinGitWebPath, builtinGitWorkerPath, builtinNodePath].map((path) => rm(path, { force: true, recursive: true })),
+    )
+  }
+}
+
+await main()

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -148,6 +148,10 @@
       "label": "Git: Delete Worktree"
     },
     {
+      "id": "git.deleteWorktree",
+      "label": "Git: Delete Worktree by Path"
+    },
+    {
       "id": "git.deleteRemoteTag",
       "label": "Git: Delete Remote Tag"
     },

--- a/packages/extension/test/ExtensionManifest.test.js
+++ b/packages/extension/test/ExtensionManifest.test.js
@@ -9,6 +9,18 @@ test('all commands have labels', () => {
   expect(missingLabels).toEqual([])
 })
 
+test('all command activation events reference declared commands', () => {
+  const manifestUrl = new URL('../extension.json', import.meta.url)
+  const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'))
+  const commandIds = new Set(manifest.commands.map((command) => command.id))
+  const undeclaredCommands = manifest.activation
+    .filter((event) => event.startsWith('onCommand:'))
+    .map((event) => event.slice('onCommand:'.length))
+    .filter((commandId) => !commandIds.has(commandId))
+
+  expect(undeclaredCommands).toEqual([])
+})
+
 test('declares the git client node rpc', () => {
   const manifestUrl = new URL('../extension.json', import.meta.url)
   const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'))

--- a/packages/git-requests/src/parts/GitRequestsDeleteWorktree/GitRequestsDeleteWorktree.ts
+++ b/packages/git-requests/src/parts/GitRequestsDeleteWorktree/GitRequestsDeleteWorktree.ts
@@ -2,6 +2,10 @@ import type { GitWorktreeRequest } from '../Types/Types.ts'
 import { GitError } from '../GitError/GitError.ts'
 import { toFileSystemPath } from '../ToFileSystemPath/ToFileSystemPath.ts'
 
+const isMissingWorktreeError = (error: unknown): boolean => {
+  return typeof error === 'object' && error !== null && 'stderr' in error && String(error.stderr).includes('is not a working tree')
+}
+
 export const deleteWorktree = async ({ cwd, exec, gitPath, worktreePath }: GitWorktreeRequest): Promise<void> => {
   try {
     const absoluteWorktreePath = toFileSystemPath(worktreePath)
@@ -12,6 +16,9 @@ export const deleteWorktree = async ({ cwd, exec, gitPath, worktreePath }: GitWo
       name: 'deleteWorktree',
     })
   } catch (error) {
+    if (isMissingWorktreeError(error)) {
+      return
+    }
     throw new GitError(error, 'deleteWorktree')
   }
 }

--- a/packages/git-requests/test/GitRequestsDeleteWorktree.test.ts
+++ b/packages/git-requests/test/GitRequestsDeleteWorktree.test.ts
@@ -84,3 +84,17 @@ test('deleteWorktree - error - unknown git error', async (): Promise<void> => {
     }),
   ).rejects.toThrow(new Error('Git: oops'))
 })
+
+test('deleteWorktree - missing worktree is a no-op', async (): Promise<void> => {
+  const exec = (): never => {
+    throw new ExecError("fatal: '/test/missing-worktree' is not a working tree")
+  }
+  await expect(
+    GitRequestsDeleteWorktree.deleteWorktree({
+      cwd: '/test/test-folder',
+      exec,
+      gitPath: 'git',
+      worktreePath: '/test/missing-worktree',
+    }),
+  ).resolves.toBeUndefined()
+})

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/server": "^0.96.12"
+    "@lvce-editor/server": "^0.96.19"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/server": "^0.94.16"
+    "@lvce-editor/server": "^0.96.12"
   }
 }

--- a/scripts/run-e2e.js
+++ b/scripts/run-e2e.js
@@ -1,13 +1,18 @@
 import { spawn } from 'node:child_process'
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { dirname, extname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
-const root = resolve(currentDir, '../../..')
+const root = resolve(currentDir, '..')
+const requireFromE2e = createRequire(join(root, 'packages', 'e2e', 'package.json'))
+const requireFromServer = createRequire(join(root, 'packages', 'server', 'package.json'))
 
 const getStaticServerPaths = async () => {
-  const staticServerPackagePath = fileURLToPath(import.meta.resolve('@lvce-editor/static-server/package.json'))
+  const serverPackagePath = requireFromServer.resolve('@lvce-editor/server/package.json')
+  const requireFromLvceServer = createRequire(serverPackagePath)
+  const staticServerPackagePath = requireFromLvceServer.resolve('@lvce-editor/static-server/package.json')
   const staticServerRoot = dirname(staticServerPackagePath)
   const staticRoot = join(staticServerRoot, 'static')
   const entries = await readdir(staticRoot, { withFileTypes: true })
@@ -79,7 +84,7 @@ const addExtensionFilesToStaticConfig = async (configPath, staticRoot, extension
 }
 
 const runTests = async (builtinExtensionsPath, builtinExtensionPath) => {
-  const testWithPlaywrightPath = fileURLToPath(import.meta.resolve('@lvce-editor/test-with-playwright/bin/test-with-playwright.js'))
+  const testWithPlaywrightPath = requireFromE2e.resolve('@lvce-editor/test-with-playwright/bin/test-with-playwright.js')
   const args = [testWithPlaywrightPath, `--only-extension=${builtinExtensionPath}`, '--test-path=.', ...process.argv.slice(2)]
   const child = spawn(process.execPath, args, {
     env: {


### PR DESCRIPTION
Updates the LVCE Editor server dependency to 0.96.19.\n\nStages the Git extension as a built-in extension during e2e tests so its scoped Node RPC capability and sibling worker bundles are available.