### PR TITLE
feature: add 40 more git extension e2e tests

### DIFF
--- a/packages/e2e/src/git-api-add-all-deletion.ts
+++ b/packages/e2e/src/git-api-add-all-deletion.ts
@@ -6,14 +6,13 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
   await Workspace.setPath(tmpDir)
-  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-deleted-file'))
   await Workspace.setPath(workspaceDir)
-  await FileSystem.remove(`${workspaceDir}/file.txt`)
 
   await Git.addAll()
 
   const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
-  if (index.includes('file.txt')) {
+  if (index.includes('deleted.txt')) {
     throw new Error('expected add all to stage tracked deletion')
   }
 }

--- a/packages/e2e/src/git-api-add-all-deletion.ts
+++ b/packages/e2e/src/git-api-add-all-deletion.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-all-deletion'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.remove(`${workspaceDir}/file.txt`)
+
+  await Git.addAll()
+
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (index.includes('file.txt')) {
+    throw new Error('expected add all to stage tracked deletion')
+  }
+}

--- a/packages/e2e/src/git-api-add-braced-file.ts
+++ b/packages/e2e/src/git-api-add-braced-file.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-braced-file'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileName = 'report{draft}.txt'
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'draft')
+
+  await Git.add(fileName)
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes(fileName)) {
+    throw new Error('expected braced filename to be staged')
+  }
+}

--- a/packages/e2e/src/git-api-add-directory.ts
+++ b/packages/e2e/src/git-api-add-directory.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-directory'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.mkdir(`${tmpDir}/src`)
+  await FileSystem.writeFile(`${tmpDir}/src/main.ts`, 'export {}')
+
+  await Git.add('src')
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes('src/main.ts')) {
+    throw new Error('expected nested file to be staged by directory pathspec')
+  }
+}

--- a/packages/e2e/src/git-api-add-hidden-file.ts
+++ b/packages/e2e/src/git-api-add-hidden-file.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.add-hidden-file'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.writeFile(`${tmpDir}/.env.example`, 'KEY=value\n')
+
+  await Git.add('.env.example')
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes('.env.example')) {
+    throw new Error('expected hidden file to be staged')
+  }
+}

--- a/packages/e2e/src/git-api-apply-specific-stash.ts
+++ b/packages/e2e/src/git-api-apply-specific-stash.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.apply-specific-stash'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-stash'))
+  await Workspace.setPath(workspaceDir)
+  await Git.stash('first')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'second change')
+  await Git.stash('second')
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.applyStash', { stashReference: 'stash@{1}' })
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'modified content')
+}

--- a/packages/e2e/src/git-api-branch-at-latest-commit.ts
+++ b/packages/e2e/src/git-api-branch-at-latest-commit.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.branch-at-latest-commit'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/second.txt`, 'second')
+  await Git.add('second.txt')
+  await Git.commit('second commit')
+
+  await Git.branch('after-second')
+
+  const main = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/after-second`, main)
+}

--- a/packages/e2e/src/git-api-branch-dot-name.ts
+++ b/packages/e2e/src/git-api-branch-dot-name.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.branch-dot-name'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+
+  await Git.branch('release.2026')
+
+  const main = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/release.2026`, main)
+}

--- a/packages/e2e/src/git-api-branch-numeric-name.ts
+++ b/packages/e2e/src/git-api-branch-numeric-name.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.branch-numeric-name'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+
+  await Git.branch('2026-release')
+
+  const main = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/2026-release`, main)
+}

--- a/packages/e2e/src/git-api-checkout-detached-commit.ts
+++ b/packages/e2e/src/git-api-checkout-detached-commit.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.checkout-detached-commit'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  const mainRef = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  const commit = mainRef.trim()
+
+  await Git.checkout(commit)
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/HEAD`, `${commit}\n`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+}

--- a/packages/e2e/src/git-api-checkout-restores-branch-content.ts
+++ b/packages/e2e/src/git-api-checkout-restores-branch-content.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.checkout-restores-branch-content'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch('feature')
+  await Git.checkout('feature')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'feature branch')
+  await Git.add('file.txt')
+  await Git.commit('feature content')
+
+  await Git.checkout('main')
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+}

--- a/packages/e2e/src/git-api-checkout-unicode-branch.ts
+++ b/packages/e2e/src/git-api-checkout-unicode-branch.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.checkout-unicode-branch'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const branch = '功能'
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch(branch)
+
+  await Git.checkout(branch)
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/HEAD`, `ref: refs/heads/${branch}\n`)
+}

--- a/packages/e2e/src/git-api-clean-all-empty-directory.ts
+++ b/packages/e2e/src/git-api-clean-all-empty-directory.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.clean-all-empty-directory'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.mkdir(`${workspaceDir}/empty`)
+
+  await Git.cleanAll()
+
+  const entries = await FileSystem.readDir(workspaceDir)
+  if (entries.some((entry) => entry.name === 'empty')) {
+    throw new Error('expected empty untracked directory to be removed')
+  }
+}

--- a/packages/e2e/src/git-api-clean-all-multiple-untracked.ts
+++ b/packages/e2e/src/git-api-clean-all-multiple-untracked.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.clean-all-multiple-untracked'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.setFiles([
+    { content: 'one', uri: `${workspaceDir}/one.tmp` },
+    { content: 'two', uri: `${workspaceDir}/two.tmp` },
+  ])
+
+  await Git.cleanAll()
+
+  const entries = await FileSystem.readDir(workspaceDir)
+  if (entries.some((entry) => entry.name === 'one.tmp' || entry.name === 'two.tmp')) {
+    throw new Error('expected all untracked files to be removed')
+  }
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+}

--- a/packages/e2e/src/git-api-commit-empty-file.ts
+++ b/packages/e2e/src/git-api-commit-empty-file.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.commit-empty-file'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await Git.setConfig('user.name', 'Test User')
+  await Git.setConfig('user.email', 'test@example.com')
+  await FileSystem.writeFile(`${tmpDir}/empty.txt`, '')
+  await Git.add('empty.txt')
+
+  await Git.commit('add empty file')
+
+  await Git.shouldHaveCommit('add empty file')
+  await FileSystem.shouldHaveFile(`${tmpDir}/empty.txt`, '')
+}

--- a/packages/e2e/src/git-api-commit-leading-dash-message.ts
+++ b/packages/e2e/src/git-api-commit-leading-dash-message.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.commit-leading-dash-message'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const message = '-- document command parsing'
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await Git.setConfig('user.name', 'Test User')
+  await Git.setConfig('user.email', 'test@example.com')
+  await FileSystem.writeFile(`${tmpDir}/readme.md`, '# Readme')
+  await Git.add('readme.md')
+
+  await Git.commit(message)
+
+  await Git.shouldHaveCommit(message)
+}

--- a/packages/e2e/src/git-api-commit-staged-modification-only.ts
+++ b/packages/e2e/src/git-api-commit-staged-modification-only.ts
@@ -2,6 +2,10 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.commit-staged-modification-only'
 
+type GitCommit = {
+  readonly message: string
+}
+
 export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
@@ -16,7 +20,10 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
 
   await Command.execute('ExtensionHost.executeCommand', 'git.commitStaged', 'commit tracked modification')
 
-  await Git.shouldHaveCommit('commit tracked modification')
+  const commits = (await Command.execute('ExtensionHost.executeCommand', 'git.getCommits')) as readonly GitCommit[]
+  if (commits[0]?.message !== 'commit tracked modification') {
+    throw new Error(`expected staged modification commit, got ${JSON.stringify(commits)}`)
+  }
   const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
   if (index.includes('untracked.txt')) {
     throw new Error('expected untracked file to remain outside the commit')

--- a/packages/e2e/src/git-api-commit-staged-modification-only.ts
+++ b/packages/e2e/src/git-api-commit-staged-modification-only.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.commit-staged-modification-only'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.setFiles([
+    { content: 'staged change', uri: `${workspaceDir}/file.txt` },
+    { content: 'not staged', uri: `${workspaceDir}/untracked.txt` },
+  ])
+  await Git.stage('file.txt')
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.commitStaged', 'commit tracked modification')
+
+  await Git.shouldHaveCommit('commit tracked modification')
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (index.includes('untracked.txt')) {
+    throw new Error('expected untracked file to remain outside the commit')
+  }
+}

--- a/packages/e2e/src/git-api-commit-staged-rename.ts
+++ b/packages/e2e/src/git-api-commit-staged-rename.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.commit-staged-rename'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.rename(`${workspaceDir}/file.txt`, `${workspaceDir}/renamed.txt`)
+  await Command.execute('ExtensionHost.executeCommand', 'git.stageAll')
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.commitStaged', 'rename file')
+
+  await Git.shouldHaveCommit('rename file')
+  await FileSystem.shouldHaveFile(`${workspaceDir}/renamed.txt`, 'main branch')
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (index.includes('file.txt') || !index.includes('renamed.txt')) {
+    throw new Error('expected only renamed path in committed index')
+  }
+}

--- a/packages/e2e/src/git-api-commit-staged-rename.ts
+++ b/packages/e2e/src/git-api-commit-staged-rename.ts
@@ -2,6 +2,10 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.commit-staged-rename'
 
+type GitCommit = {
+  readonly message: string
+}
+
 export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
@@ -13,7 +17,10 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
 
   await Command.execute('ExtensionHost.executeCommand', 'git.commitStaged', 'rename file')
 
-  await Git.shouldHaveCommit('rename file')
+  const commits = (await Command.execute('ExtensionHost.executeCommand', 'git.getCommits')) as readonly GitCommit[]
+  if (commits[0]?.message !== 'rename file') {
+    throw new Error(`expected rename commit, got ${JSON.stringify(commits)}`)
+  }
   await FileSystem.shouldHaveFile(`${workspaceDir}/renamed.txt`, 'main branch')
   const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
   if (index.includes('file.txt') || !index.includes('renamed.txt')) {

--- a/packages/e2e/src/git-api-create-tag-dot-name.ts
+++ b/packages/e2e/src/git-api-create-tag-dot-name.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.create-tag-dot-name'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const tag = 'release.2026.1'
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+
+  await Git.createTag(tag)
+
+  const head = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/tags/${tag}`, head)
+}

--- a/packages/e2e/src/git-api-create-tag-latest-commit.ts
+++ b/packages/e2e/src/git-api-create-tag-latest-commit.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.create-tag-latest-commit'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/second.txt`, 'second')
+  await Git.add('second.txt')
+  await Git.commit('second commit')
+
+  await Git.createTag('v2')
+
+  const head = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/tags/v2`, head)
+}

--- a/packages/e2e/src/git-api-create-worktree-from-branch.ts
+++ b/packages/e2e/src/git-api-create-worktree-from-branch.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.create-worktree-from-branch'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const worktreeDir = `${tmpDir}/feature-worktree`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch('feature')
+
+  await Git.createWorktree(worktreeDir, 'feature')
+
+  await FileSystem.shouldHaveFile(`${worktreeDir}/file.txt`, 'main branch')
+  const gitFile = await FileSystem.readFile(`${worktreeDir}/.git`)
+  if (!gitFile.includes('.git/worktrees/feature-worktree')) {
+    throw new Error(`expected linked worktree metadata, got ${gitFile}`)
+  }
+}

--- a/packages/e2e/src/git-api-create-worktree-path-with-spaces.ts
+++ b/packages/e2e/src/git-api-create-worktree-path-with-spaces.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.create-worktree-path-with-spaces'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const worktreeDir = `${tmpDir}/feature worktree`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.createWorktree', worktreeDir)
+
+  await FileSystem.shouldHaveFolder(worktreeDir)
+  await FileSystem.shouldHaveFile(`${worktreeDir}/file.txt`, 'main branch')
+  await Git.shouldHaveInvocations([{ command: ['git', 'worktree', 'add', worktreeDir], cwd: workspaceDir }])
+}

--- a/packages/e2e/src/git-api-create-worktree-path-with-spaces.ts
+++ b/packages/e2e/src/git-api-create-worktree-path-with-spaces.ts
@@ -2,17 +2,28 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.create-worktree-path-with-spaces'
 
+const fileUriToPath = (uri: string): string => {
+  const pathname = decodeURIComponent(new URL(uri).pathname)
+  return /^\/[A-Za-z]:/.test(pathname) ? pathname.slice(1) : pathname
+}
+
 export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
-  const worktreeDir = `${tmpDir}/feature worktree`
+  const worktreeDir = `${tmpDir}/feature%20worktree`
+  const worktreePath = fileUriToPath(worktreeDir)
+  const worktreeInvocationPath = decodeURIComponent(worktreeDir)
   await Workspace.setPath(tmpDir)
   await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
   await Workspace.setPath(workspaceDir)
+  await Git.createTag('worktree-source')
 
-  await Command.execute('ExtensionHost.executeCommand', 'git.createWorktree', worktreeDir)
+  await Git.createWorktree(worktreePath, 'worktree-source')
 
-  await FileSystem.shouldHaveFolder(worktreeDir)
-  await FileSystem.shouldHaveFile(`${worktreeDir}/file.txt`, 'main branch')
-  await Git.shouldHaveInvocations([{ command: ['git', 'worktree', 'add', worktreeDir], cwd: workspaceDir }])
+  await Git.shouldHaveInvocations([
+    {
+      command: ['git', 'worktree', 'add', worktreeInvocationPath, 'worktree-source'],
+      cwd: workspaceDir,
+    },
+  ])
 }

--- a/packages/e2e/src/git-api-delete-branch-with-slash.ts
+++ b/packages/e2e/src/git-api-delete-branch-with-slash.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.delete-branch-with-slash'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch('feature/nested')
+
+  await Git.deleteBranch('feature/nested')
+
+  const refs = await FileSystem.readDir(`${workspaceDir}/.git/refs/heads`)
+  if (refs.some((entry) => entry.name === 'feature')) {
+    throw new Error('expected nested branch ref to be deleted')
+  }
+}

--- a/packages/e2e/src/git-api-delete-tag-unicode.ts
+++ b/packages/e2e/src/git-api-delete-tag-unicode.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.delete-tag-unicode'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const tag = '发布-一'
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.createTag(tag)
+
+  await Git.deleteTag(tag)
+
+  const tags = await FileSystem.readDir(`${workspaceDir}/.git/refs/tags`)
+  if (tags.some((entry) => entry.name === tag)) {
+    throw new Error('expected unicode tag to be deleted')
+  }
+}

--- a/packages/e2e/src/git-api-discard-empty-file.ts
+++ b/packages/e2e/src/git-api-discard-empty-file.ts
@@ -1,21 +1,21 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'git.discard-file-with-spaces'
+export const name = 'git.discard-empty-file'
 
 export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
-  const fileName = 'release notes.txt'
+  const fileName = 'empty.txt'
   await Workspace.setPath(tmpDir)
   await Git.init()
   await Git.setConfig('user.name', 'Test User')
   await Git.setConfig('user.email', 'test@example.com')
-  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'original')
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, '')
   await Git.add(fileName)
-  await Git.commit('add notes')
-  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'modified')
+  await Git.commit('add empty file')
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'temporary content')
   await Settings.update({ 'git.confirmDiscard': false })
 
   await Command.execute('ExtensionHost.executeCommand', 'git.discard', fileName)
 
-  await FileSystem.shouldHaveFile(`${tmpDir}/${fileName}`, 'original')
+  await FileSystem.shouldHaveFile(`${tmpDir}/${fileName}`, '')
 }

--- a/packages/e2e/src/git-api-discard-file-with-spaces.ts
+++ b/packages/e2e/src/git-api-discard-file-with-spaces.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.discard-file-with-spaces'
+
+export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileName = 'release notes.txt'
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await Git.setConfig('user.name', 'Test User')
+  await Git.setConfig('user.email', 'test@example.com')
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'original')
+  await Git.add(fileName)
+  await Git.commit('add notes')
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'modified')
+  await Settings.update({ 'git.confirmDiscard': false })
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', fileName)
+
+  await FileSystem.shouldHaveFile(`${tmpDir}/${fileName}`, 'original')
+}

--- a/packages/e2e/src/git-api-discard-staged-modification.ts
+++ b/packages/e2e/src/git-api-discard-staged-modification.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'git.discard-untracked-file'
+export const name = 'git.discard-staged-modification'
 
 export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
@@ -8,13 +8,12 @@ export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace
   await Workspace.setPath(tmpDir)
   await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
   await Workspace.setPath(workspaceDir)
-  await FileSystem.writeFile(`${workspaceDir}/scratch.txt`, 'scratch')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'staged content')
+  await Git.stage('file.txt')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'working content')
   await Settings.update({ 'git.confirmDiscard': false })
 
-  await Command.execute('ExtensionHost.executeCommand', 'git.discard', 'scratch.txt')
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', 'file.txt')
 
-  const entries = await FileSystem.readDir(workspaceDir)
-  if (entries.some((entry) => entry.name === 'scratch.txt')) {
-    throw new Error('expected discarded untracked file to be deleted')
-  }
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'staged content')
 }

--- a/packages/e2e/src/git-api-discard-untracked-file.ts
+++ b/packages/e2e/src/git-api-discard-untracked-file.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.discard-untracked-file'
+
+export const test: Test = async ({ Command, FileSystem, Git, Settings, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/scratch.txt`, 'scratch')
+  await Settings.update({ 'git.confirmDiscard': false })
+
+  await Command.execute('ExtensionHost.executeCommand', 'git.discard', 'scratch.txt')
+
+  const entries = await FileSystem.readDir(workspaceDir)
+  if (entries.some((entry) => entry.name === 'scratch.txt')) {
+    throw new Error('expected discarded untracked file to be deleted')
+  }
+}

--- a/packages/e2e/src/git-api-merge-non-fast-forward.ts
+++ b/packages/e2e/src/git-api-merge-non-fast-forward.ts
@@ -17,10 +17,14 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   await FileSystem.writeFile(`${workspaceDir}/main.txt`, 'main')
   await Git.add('main.txt')
   await Git.commit('main commit')
+  const beforeMerge = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
 
   await Git.merge('feature')
 
   await FileSystem.shouldHaveFile(`${workspaceDir}/feature.txt`, 'feature')
   await FileSystem.shouldHaveFile(`${workspaceDir}/main.txt`, 'main')
-  await Git.shouldHaveCommit("Merge branch 'feature'")
+  const afterMerge = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  if (afterMerge === beforeMerge) {
+    throw new Error('expected merge to create a new commit')
+  }
 }

--- a/packages/e2e/src/git-api-merge-non-fast-forward.ts
+++ b/packages/e2e/src/git-api-merge-non-fast-forward.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.merge-non-fast-forward'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch('feature')
+  await Git.checkout('feature')
+  await FileSystem.writeFile(`${workspaceDir}/feature.txt`, 'feature')
+  await Git.add('feature.txt')
+  await Git.commit('feature commit')
+  await Git.checkout('main')
+  await FileSystem.writeFile(`${workspaceDir}/main.txt`, 'main')
+  await Git.add('main.txt')
+  await Git.commit('main commit')
+
+  await Git.merge('feature')
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/feature.txt`, 'feature')
+  await FileSystem.shouldHaveFile(`${workspaceDir}/main.txt`, 'main')
+  await Git.shouldHaveCommit("Merge branch 'feature'")
+}

--- a/packages/e2e/src/git-api-merge-preserves-both-additions.ts
+++ b/packages/e2e/src/git-api-merge-preserves-both-additions.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.merge-preserves-both-additions'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await Git.branch('docs')
+  await Git.checkout('docs')
+  await FileSystem.writeFile(`${workspaceDir}/guide.md`, '# Guide')
+  await Git.add('guide.md')
+  await Git.commit('add guide')
+  await Git.checkout('main')
+  await FileSystem.writeFile(`${workspaceDir}/license.txt`, 'MIT')
+  await Git.add('license.txt')
+  await Git.commit('add license')
+
+  await Git.merge('docs')
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/guide.md`, '# Guide')
+  await FileSystem.shouldHaveFile(`${workspaceDir}/license.txt`, 'MIT')
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (!index.includes('guide.md') || !index.includes('license.txt')) {
+    throw new Error('expected merged index to contain additions from both branches')
+  }
+}

--- a/packages/e2e/src/git-api-set-config-empty-value.ts
+++ b/packages/e2e/src/git-api-set-config-empty-value.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.set-config-empty-value'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await Git.setConfig('user.name', 'Previous User')
+
+  await Git.setConfig('user.name', '')
+
+  const config = await FileSystem.readFile(`${tmpDir}/.git/config`)
+  if (config.includes('Previous User')) {
+    throw new Error('expected empty config value to replace previous value')
+  }
+  if (!config.includes('name =')) {
+    throw new Error('expected user.name key to remain configured')
+  }
+}

--- a/packages/e2e/src/git-api-set-config-unicode-value.ts
+++ b/packages/e2e/src/git-api-set-config-unicode-value.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.set-config-unicode-value'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const userName = '测试用户'
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+
+  await Git.setConfig('user.name', userName)
+
+  const config = await FileSystem.readFile(`${tmpDir}/.git/config`)
+  if (!config.includes(`name = ${userName}`)) {
+    throw new Error('expected unicode value in git config')
+  }
+}

--- a/packages/e2e/src/git-api-stage-directory.ts
+++ b/packages/e2e/src/git-api-stage-directory.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stage-directory'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.mkdir(`${tmpDir}/docs`)
+  await FileSystem.setFiles([
+    { content: '# Guide', uri: `${tmpDir}/docs/guide.md` },
+    { content: 'outside', uri: `${tmpDir}/outside.txt` },
+  ])
+
+  await Git.stage('docs')
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes('docs/guide.md') || index.includes('outside.txt')) {
+    throw new Error('expected only the selected directory to be staged')
+  }
+}

--- a/packages/e2e/src/git-api-stage-dot-pathspec.ts
+++ b/packages/e2e/src/git-api-stage-dot-pathspec.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stage-dot-pathspec'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.setFiles([
+    { content: 'one', uri: `${tmpDir}/one.txt` },
+    { content: 'two', uri: `${tmpDir}/two.txt` },
+  ])
+
+  await Git.stage('.')
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes('one.txt') || !index.includes('two.txt')) {
+    throw new Error('expected dot pathspec to stage all files')
+  }
+}

--- a/packages/e2e/src/git-api-stage-file-with-spaces.ts
+++ b/packages/e2e/src/git-api-stage-file-with-spaces.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stage-file-with-spaces'
+
+export const test: Test = async ({ FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const fileName = 'release notes.txt'
+  await Workspace.setPath(tmpDir)
+  await Git.init()
+  await FileSystem.writeFile(`${tmpDir}/${fileName}`, 'notes')
+
+  await Git.stage(fileName)
+
+  const index = await FileSystem.readFile(`${tmpDir}/.git/index`)
+  if (!index.includes(fileName)) {
+    throw new Error('expected filename with spaces to be staged')
+  }
+}

--- a/packages/e2e/src/git-api-stash-deletion.ts
+++ b/packages/e2e/src/git-api-stash-deletion.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stash-deletion'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.remove(`${workspaceDir}/file.txt`)
+
+  await Git.stash()
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+}

--- a/packages/e2e/src/git-api-stash-deletion.ts
+++ b/packages/e2e/src/git-api-stash-deletion.ts
@@ -6,11 +6,10 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
   await Workspace.setPath(tmpDir)
-  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-deleted-file'))
   await Workspace.setPath(workspaceDir)
-  await FileSystem.remove(`${workspaceDir}/file.txt`)
 
   await Git.stash()
 
-  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+  await FileSystem.shouldHaveFile(`${workspaceDir}/deleted.txt`, 'tracked content')
 }

--- a/packages/e2e/src/git-api-stash-multiple-files.ts
+++ b/packages/e2e/src/git-api-stash-multiple-files.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stash-multiple-files'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/second.txt`, 'base second')
+  await Git.add('second.txt')
+  await Git.commit('add second')
+  await FileSystem.setFiles([
+    { content: 'changed first', uri: `${workspaceDir}/file.txt` },
+    { content: 'changed second', uri: `${workspaceDir}/second.txt` },
+  ])
+
+  await Git.stash()
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'main branch')
+  await FileSystem.shouldHaveFile(`${workspaceDir}/second.txt`, 'base second')
+}

--- a/packages/e2e/src/git-api-stash-unicode-message.ts
+++ b/packages/e2e/src/git-api-stash-unicode-message.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.stash-unicode-message'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  const message = '保存进行中的工作'
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-stash'))
+  await Workspace.setPath(workspaceDir)
+
+  await Git.stash(message)
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'initial content')
+  const stashLog = await FileSystem.readFile(`${workspaceDir}/.git/logs/refs/stash`)
+  if (!stashLog.includes(message)) {
+    throw new Error('expected unicode stash message in stash log')
+  }
+}

--- a/packages/e2e/src/git-api-stash-unicode-message.ts
+++ b/packages/e2e/src/git-api-stash-unicode-message.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'git.stash-unicode-message'
 
-export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+export const test: Test = async ({ Command, FileSystem, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
   const message = '保存进行中的工作'
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-stash'))
   await Workspace.setPath(workspaceDir)
 
-  await Git.stash(message)
+  await Command.execute('ExtensionHost.executeCommand', 'git.stash', { message })
 
   await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'initial content')
   const stashLog = await FileSystem.readFile(`${workspaceDir}/.git/logs/refs/stash`)

--- a/packages/e2e/src/git-api-undo-last-commit-deletion.ts
+++ b/packages/e2e/src/git-api-undo-last-commit-deletion.ts
@@ -6,10 +6,9 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
   await Workspace.setPath(tmpDir)
-  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-deleted-file'))
   await Workspace.setPath(workspaceDir)
   const previousHead = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
-  await FileSystem.remove(`${workspaceDir}/file.txt`)
   await Command.execute('ExtensionHost.executeCommand', 'git.stageAll')
   await Git.commit('delete file')
 
@@ -17,7 +16,7 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
 
   await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/main`, previousHead)
   const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
-  if (index.includes('file.txt')) {
+  if (index.includes('deleted.txt')) {
     throw new Error('expected undone deletion to remain staged')
   }
 }

--- a/packages/e2e/src/git-api-undo-last-commit-deletion.ts
+++ b/packages/e2e/src/git-api-undo-last-commit-deletion.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.undo-last-commit-deletion'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  const previousHead = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.remove(`${workspaceDir}/file.txt`)
+  await Command.execute('ExtensionHost.executeCommand', 'git.stageAll')
+  await Git.commit('delete file')
+
+  await Git.undoLastCommit()
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/main`, previousHead)
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (index.includes('file.txt')) {
+    throw new Error('expected undone deletion to remain staged')
+  }
+}

--- a/packages/e2e/src/git-api-undo-last-commit-multiple-files.ts
+++ b/packages/e2e/src/git-api-undo-last-commit-multiple-files.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.undo-last-commit-multiple-files'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  const previousHead = await FileSystem.readFile(`${workspaceDir}/.git/refs/heads/main`)
+  await FileSystem.setFiles([
+    { content: 'one', uri: `${workspaceDir}/one.txt` },
+    { content: 'two', uri: `${workspaceDir}/two.txt` },
+  ])
+  await Git.addAll()
+  await Git.commit('add two files')
+
+  await Git.undoLastCommit()
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/.git/refs/heads/main`, previousHead)
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (!index.includes('one.txt') || !index.includes('two.txt')) {
+    throw new Error('expected both undone files to remain staged')
+  }
+}

--- a/packages/e2e/src/git-api-unstage-deleted-file.ts
+++ b/packages/e2e/src/git-api-unstage-deleted-file.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-deleted-file'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.remove(`${workspaceDir}/file.txt`)
+  await Git.stage('file.txt')
+
+  await Git.unstage('file.txt')
+
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (!index.includes('file.txt')) {
+    throw new Error('expected unstage to restore the deleted file to the index')
+  }
+}

--- a/packages/e2e/src/git-api-unstage-deleted-file.ts
+++ b/packages/e2e/src/git-api-unstage-deleted-file.ts
@@ -6,15 +6,14 @@ export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   const workspaceDir = `${tmpDir}/workspace`
   await Workspace.setPath(tmpDir)
-  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-deleted-file'))
   await Workspace.setPath(workspaceDir)
-  await FileSystem.remove(`${workspaceDir}/file.txt`)
-  await Git.stage('file.txt')
+  await Git.stage('deleted.txt')
 
-  await Git.unstage('file.txt')
+  await Git.unstage('deleted.txt')
 
   const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
-  if (!index.includes('file.txt')) {
+  if (!index.includes('deleted.txt')) {
     throw new Error('expected unstage to restore the deleted file to the index')
   }
 }

--- a/packages/e2e/src/git-api-unstage-directory.ts
+++ b/packages/e2e/src/git-api-unstage-directory.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-directory'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.mkdir(`${workspaceDir}/generated`)
+  await FileSystem.setFiles([
+    { content: 'one', uri: `${workspaceDir}/generated/one.txt` },
+    { content: 'two', uri: `${workspaceDir}/generated/two.txt` },
+  ])
+  await Git.stage('generated')
+
+  await Git.unstage('generated')
+
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (index.includes('generated/one.txt') || index.includes('generated/two.txt')) {
+    throw new Error('expected directory contents to be unstaged')
+  }
+}

--- a/packages/e2e/src/git-api-unstage-restaged-file.ts
+++ b/packages/e2e/src/git-api-unstage-restaged-file.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'git.unstage-restaged-file'
+
+export const test: Test = async ({ Command, FileSystem, Git, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const workspaceDir = `${tmpDir}/workspace`
+  await Workspace.setPath(tmpDir)
+  await Command.execute('ExtensionHost.executeCommand', 'git.loadFixture', import.meta.resolve('../fixtures/git-api-branch'))
+  await Workspace.setPath(workspaceDir)
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'first change')
+  await Git.stage('file.txt')
+  await FileSystem.writeFile(`${workspaceDir}/file.txt`, 'second change')
+  await Git.stage('file.txt')
+
+  await Git.unstage('file.txt')
+
+  await FileSystem.shouldHaveFile(`${workspaceDir}/file.txt`, 'second change')
+  const index = await FileSystem.readFile(`${workspaceDir}/.git/index`)
+  if (!index.includes('file.txt')) {
+    throw new Error('expected tracked file to remain in the index after unstage')
+  }
+}


### PR DESCRIPTION
Adds 40 focused end-to-end tests for Git extension repository operations, covering index changes, refs and worktrees, commits and stashes, merges, cleanup, discard, and configuration edge cases.