### PR TITLE
fix: initialize websocket issuer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,9 +2282,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.96.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.19.tgz",
-      "integrity": "sha512-SRcZm4hq0J+OciOxrhPZEpdVSXlqzHXGYUMvaNGXN72Xj43Jma2+cF+TIYqWsbX2JdFFpaxngkxXfD3VamI1Qg==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.15.tgz",
+      "integrity": "sha512-p5u9PSZ/+KalknuumzYgdJm7R3pnr19Aq/cdQ6hRHDd1GKyokrkgpYUj6VXCeA92fN3bCOd5LD/zFkVf3dyLZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2298,9 +2298,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
-      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2731,14 +2731,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.96.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.19.tgz",
-      "integrity": "sha512-MRJpvLx14tks7cJyxscgXaLqE6I5og1onZgFE5a4u/XK9cDGqoRd6IEBCA9SGBRDO2FUcxr6ftCEMVcrqbu7ow==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.15.tgz",
+      "integrity": "sha512-WXS0sgVt6UzKTyXTkoGOT8JO5dv6mKfUn+KqAyMmcK/Hq7ug2FdnwlihVDthDt8L9vIR/lk1lr+lm3NKGpRV0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.96.19",
-        "@lvce-editor/static-server": "0.96.19"
+        "@lvce-editor/shared-process": "0.99.15",
+        "@lvce-editor/static-server": "0.99.15"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2748,14 +2748,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.96.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.19.tgz",
-      "integrity": "sha512-ggbr/bq1hONBOidoLq4/TCfTuwmt/XfdCv82jZma9KSDn/xeRhyuQJO/Y7gSU1wmAiXNlOugvpeisvSBF0GaPg==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.15.tgz",
+      "integrity": "sha512-KJ1wKvbZ/pQYqmH14eBSwces4L83tNrUqSD/ude4icmojyextS10IgMw6DEcjCnNB534xLG/9TO1p5QvM0L7hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.96.19",
+        "@lvce-editor/extension-host-helper-process": "0.99.15",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2772,13 +2772,13 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-system-process": "5.12.0",
         "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/search-process": "15.7.0",
         "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -2787,9 +2787,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.96.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.19.tgz",
-      "integrity": "sha512-7GmhhrcCLDK6ZbB/ss3PVWrn/096BzPib+vxkbbTsox0zWpBuzwytfMV4rdtH4bSoVIvJPTgpWfxo185VjZVBw==",
+      "version": "0.99.15",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.15.tgz",
+      "integrity": "sha512-3DsY2FecidhZM9+tXsRyp3GQBSU2Qa7wJX5a+MZLNJE26UbQvAf0bxmnX2XVvmDP/WKnWhp/TZ8NMx47N/SCGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15090,7 +15090,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/server": "^0.96.19"
+        "@lvce-editor/server": "^0.99.15"
       }
     }
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/server": "^0.96.19"
+    "@lvce-editor/server": "^0.99.15"
   }
 }


### PR DESCRIPTION
## Summary
- update `@lvce-editor/server` to a version that initializes the WebSocket issuer
- refresh the lockfile and transitive server runtime packages

## Validation
- `npm run build`
- `npm run build:static`
- `npm test`
- `npm run type-check`
- `npm run lint`
- verified three document responses contain distinct 43-character `webSocketIssuer` values